### PR TITLE
Update React app to send product id as string

### DIFF
--- a/typescript/ecommerce-store/react-shopping-cart/src/contexts/cart-context/useCartProducts.ts
+++ b/typescript/ecommerce-store/react-shopping-cart/src/contexts/cart-context/useCartProducts.ts
@@ -57,7 +57,7 @@ const useCartProducts = () => {
     const updatedProducts = products.filter(
       (product: ICartProduct) => product.id !== productToRemove.id
     );
-    const req = { "shopping_cart_id": user!.shopping_cart_id, "product_id": productToRemove.id };
+    const req = { "shopping_cart_id": user!.shopping_cart_id, "product_id": ""+productToRemove.id };
 
     grpc('ShoppingCartService', 'RemoveProduct', req).then((res: any) => {
       setProducts(updatedProducts);


### PR DESCRIPTION
This commit fixes a minor bug in the remove product call: the product id in the remove command was sent as a number, but it is expected to be a string by the service schema.

Before this fix, clicking on the "remove" button next to a product in the cart results in the following error:

```
docker-runtime-1       | 2023-09-21T13:45:42.409410Z WARN restate_ingress_grpc::protocol::connect_adapter
docker-runtime-1       |   Error when parsing request: invalid type: integer `11`, expected a string at line 1 column 75
```

This is because `RemoveProductRequest` expects `product_id` to be a string in https://github.com/restatedev/examples/blob/main/typescript/ecommerce-store/services/proto/shoppingcart.proto#L168.