### PR TITLE
Delete .npmrc, create it on the fly in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Create .npmrc
         run: |
-          echo '@restatedev:registry=https://npm.pkg.github.com/' > ~/.npmrc
-          echo '//npm.pkg.github.com/:_authToken=${GH_PACKAGE_READ_ACCESS_TOKEN}' >> ~/.npmrc
+          echo '@restatedev:registry=https://npm.pkg.github.com/' > typescript/.npmrc
+          echo '//npm.pkg.github.com/:_authToken=${GH_PACKAGE_READ_ACCESS_TOKEN}' >> typescript/.npmrc
       - run: npm ci --prefix typescript
         env:
           GH_PACKAGE_READ_ACCESS_TOKEN: ${{ secrets.GH_PACKAGE_READ_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Create .npmrc
+        run: |
+          echo '@restatedev:registry=https://npm.pkg.github.com/' > ~/.npmrc
+          echo '//npm.pkg.github.com/:_authToken=${GH_PACKAGE_READ_ACCESS_TOKEN}' >> ~/.npmrc
       - run: npm ci --prefix typescript
         env:
           GH_PACKAGE_READ_ACCESS_TOKEN: ${{ secrets.GH_PACKAGE_READ_ACCESS_TOKEN }}

--- a/typescript/.npmrc
+++ b/typescript/.npmrc
@@ -1,2 +1,0 @@
-@restatedev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GH_PACKAGE_READ_ACCESS_TOKEN}


### PR DESCRIPTION
For local development we assume that npm is already properly configured. Removing the bundled dot file avoids overriding personal configurations.