### PR TITLE
New release process

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,83 @@
+name: Pre-release updates
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdkTypescriptVersion:
+        description: 'sdk-typescript version (without prepending v). Leave empty if you do not want to update it.'
+        required: false
+        type: string
+      sdkJavaVersion:
+        description: 'sdk-java version (without prepending v). Leave empty if you do not want to update it.'
+        required: false
+        type: string
+
+jobs:
+  updates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup node
+      - uses: actions/setup-node@v3
+        if: github.event.inputs.sdkTypescriptVersion != ''
+        with:
+          node-version: "19.x"
+          registry-url: 'https://registry.npmjs.org'
+
+      # Bump sdk version in node examples and run checks
+      - name: Run npm updates
+        if: github.event.inputs.sdkTypescriptVersion != ''
+        run: npm --prefix typescript install @restatedev/restate-sdk@^${{ inputs.sdkTypescriptVersion }} --workspaces
+      - name: Check npm examples compile correctly
+        if: github.event.inputs.sdkTypescriptVersion != ''
+        run: npm --prefix typescript run verify --workspaces
+
+      # Setup Java
+      - uses: actions/setup-java@v3
+        if: github.event.inputs.sdkJavaVersion != ''
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Bump sdk version in java examples and run checks
+      - name: Find and replace restateVersion in build.gradle.kts
+        if: github.event.inputs.sdkJavaVersion != ''
+        run: for jvmDir in java-blocking-http java-blocking-lambda kotlin-http kotlin-lambda; do sed -i 's/val restateVersion = "[0-9A-Z.-]*"/val restateVersion = "${{ inputs.sdkJavaVersion }}"/' jvm/$jvmDir/build.gradle.kts; done
+      - name: Test jvm/java-blocking-http
+        if: github.event.inputs.sdkJavaVersion != ''
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/java-blocking-http
+      - name: Test jvm/java-blocking-lambda
+        if: github.event.inputs.sdkJavaVersion != ''
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/java-blocking-lambda
+      - name: Test jvm/kotlin-http
+        if: github.event.inputs.sdkJavaVersion != ''
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/kotlin-http
+      - name: Test jvm/kotlin-lambda
+        if: github.event.inputs.sdkJavaVersion != ''
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/kotlin-lambda
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[GithubActions] Update Restate SDK-Typescript '${{ inputs.sdkTypescriptVersion }}' SDK-Java '${{ inputs.sdkJavaVersion }}'"
+          commit-message: "[GithubActions] Update Restate SDK-Typescript '${{ inputs.sdkTypescriptVersion }}' SDK-Java '${{ inputs.sdkJavaVersion }}'"
+          add-paths: |
+            **/package.json
+            **/package-lock.json
+            **/build.gradle.kts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Create new release
+
+on:
+  push:
+    tags:
+      - v**
+
+jobs:
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Prepare zip files
+        run: ./scripts/prepare_examples_zip.sh
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          # create a draft release which needs manual approval
+          draft: true
+          files: |
+            typescript-lambda-greeter.zip
+            jvm-java-blocking-http.zip
+            jvm-java-blocking-lambda.zip
+            jvm-kotlin-http.zip
+            jvm-kotlin-lambda.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,44 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-jvm:
+    # prevent from running on forks
+    if: github.repository_owner == 'restatedev'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jvm-version: [ 17 ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use JVM ${{ matrix.jvm-version }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jvm-version }}
+
+      - name: Test jvm/java-blocking-http
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/java-blocking-http
+      - name: Test jvm/java-blocking-lambda
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/java-blocking-lambda
+      - name: Test jvm/kotlin-http
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/kotlin-http
+      - name: Test jvm/kotlin-lambda
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+          build-root-directory: jvm/kotlin-lambda
+  build-ts:
     # prevent from running on forks
     if: github.repository_owner == 'restatedev'
     runs-on: ubuntu-latest
@@ -17,11 +54,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: bufbuild/buf-setup-action@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+
       - run: npm ci --prefix typescript
       - run: npm run --prefix typescript -ws verify

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ Browse this repository to see how easy distributed applications development beco
 If you want to join the Restate community in order to stay up to date, then please join our [Discord](https://discord.gg/skW3AZ6uGd).
 The Discord server is also the perfect place for sharing your feedback with us, learning more about Restate and connect with others!
 
-## Running the examples
-
-> **Note**
-> Make sure you have [signed up for Restate's private beta](https://forms.gle/G8kDuucqhBoTfMwLA) and set up [access to Restate's packages](https://github.com/restatedev/restate-dist).
-
 ### Launching the runtime
 
 Have a look at how to start up the runtime in a Docker container in [this repository]* or run the following commands:
@@ -77,27 +72,8 @@ This should give you the following output in case of the ticket reservation exam
 
 ## Releasing (for Restate developers)
 
-In order to create a new release, push a tag of the form `vX.Y.Z`.
-Then [create a release via GitHub](https://github.com/restatedev/example-lambda-ts-greeter/releases).
+Before releasing, trigger the "pre-release" workflow to update sdk versions. This automatically creates a pull request, which must be manually merged.  
 
-### Upgrading the SDK dependency (for Restate developers)
+Once the repo is ready for the release, push a tag of the form `vX.Y.Z`. 
 
-In order to upgrade/update the SDK dependency you have to run:
-
-**Major version** change:
-
-```shell
-npm --prefix typescript install @restatedev/restate-sdk@^Z.Y.X --workspaces
-```
-
-**Minor/patch version** change:
-
-```shell
-npm --prefix typescript update @restatedev/restate-sdk --workspaces
-```
-
-Now check whether the examples are still building:
-
-```shell
-npm --prefix typescript run verify --workspaces
-```
+This triggers a workflow that [creates a draft release](https://github.com/restatedev/examples/releases) on Github, which you need to approve to finalize it.

--- a/scripts/prepare_examples_zip.sh
+++ b/scripts/prepare_examples_zip.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+OUT_DIR="$(pwd)"
+
+zip_ts_example() {
+  pushd typescript && zip -r typescript-$1.zip $1 -x '*node_modules*' '*dist*' && popd || exit
+  mv typescript/typescript-$1.zip $OUT_DIR
+  echo "Zip for $1 in $OUT_DIR/typescript-$1.zip"
+}
+
+zip_jvm_example() {
+  pushd jvm && zip -r jvm-$1.zip $1 -x '*.gradle*' '*build*' '*.idea*' && popd || exit
+  mv jvm/jvm-$1.zip $OUT_DIR
+  echo "Zip for $1 in $OUT_DIR/jvm-$1.zip"
+}
+
+zip_ts_example lambda-greeter
+
+zip_jvm_example java-blocking-http
+zip_jvm_example java-blocking-lambda
+zip_jvm_example kotlin-http
+zip_jvm_example kotlin-lambda


### PR DESCRIPTION
Depends on #42. Fix #40 

* Now releasing examples follows a similar flow to the documentation repo
* There is a pre-release workflow that performs all the sdk updates
* Then the release workflow zips the sdk-java and typescript lambda greeter examples, and adds them to the GH release artifacts