### PR TITLE
Add correct transformers to gradle build configurations

### DIFF
--- a/java/hello-world-lambda/build.gradle.kts
+++ b/java/hello-world-lambda/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import com.google.protobuf.gradle.id
 
 plugins {
@@ -56,6 +59,12 @@ protobuf {
       }
     }
   }
+}
+
+// Configure shadowJar plugin to properly merge SPI files and Log4j plugin configurations
+tasks.withType<ShadowJar> {
+  transform(Log4j2PluginsCacheFileTransformer::class.java)
+  transform(ServiceFileTransformer::class.java)
 }
 
 // Configure test platform

--- a/kotlin/hello-world-lambda-cdk/lambda/build.gradle.kts
+++ b/kotlin/hello-world-lambda-cdk/lambda/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import com.google.protobuf.gradle.id
 
 val restateVersion = "0.6.0"
@@ -80,9 +81,10 @@ protobuf {
   }
 }
 
-// Configure shadowJar plugin to properly transform Log4j plugin configurations - needed for AWS Lambda logger
+// Configure shadowJar plugin to properly merge SPI files and Log4j plugin configurations
 tasks.withType<ShadowJar> {
   transform(Log4j2PluginsCacheFileTransformer::class.java)
+  transform(ServiceFileTransformer::class.java)
 }
 
 // Configure test platform

--- a/kotlin/hello-world-lambda/build.gradle.kts
+++ b/kotlin/hello-world-lambda/build.gradle.kts
@@ -1,5 +1,7 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import com.google.protobuf.gradle.id
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   kotlin("jvm") version "1.9.10"
@@ -74,6 +76,12 @@ protobuf {
       }
     }
   }
+}
+
+// Configure shadowJar plugin to properly merge SPI files and Log4j plugin configurations
+tasks.withType<ShadowJar> {
+  transform(Log4j2PluginsCacheFileTransformer::class.java)
+  transform(ServiceFileTransformer::class.java)
 }
 
 // Configure test platform


### PR DESCRIPTION
Without the `ServiceFileTransformer`, SPI files won't be merged. See https://github.com/apache/logging-log4j2/issues/2099

Because the `GrpcContextDataProvider` is not needed in the lambda case (everything is on the same thread anyway, so `LoggingContextSetter` in the state machine is enough), we could also solve this issue differently, by having a separate module in the SDK that imports the `GrpcContextDataProvider` only for the sdk-http-vertx case... Although perhaps let's see what they propose in the log4j2 issue and let's take action based on that... WDYT? 