### PR TITLE
Fixes for 0.7.0 release

### DIFF
--- a/java/hello-world-http/build.gradle.kts
+++ b/java/hello-world-http/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
   mavenCentral()
 }
 
-val restateVersion = "0.6.0"
+val restateVersion = "0.7.0"
 
 dependencies {
   // Restate SDK

--- a/java/hello-world-lambda/build.gradle.kts
+++ b/java/hello-world-lambda/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
   mavenCentral()
 }
 
-val restateVersion = "0.6.0"
+val restateVersion = "0.7.0"
 
 dependencies {
   // Restate SDK

--- a/kotlin/hello-world-http/build.gradle.kts
+++ b/kotlin/hello-world-http/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
   mavenCentral()
 }
 
-val restateVersion = "0.6.0"
+val restateVersion = "0.7.0"
 
 dependencies {
   // Restate SDK

--- a/kotlin/hello-world-lambda-cdk/lambda/build.gradle.kts
+++ b/kotlin/hello-world-lambda-cdk/lambda/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCach
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import com.google.protobuf.gradle.id
 
-val restateVersion = "0.6.0"
+val restateVersion = "0.7.0"
 
 plugins {
   kotlin("jvm") version "1.9.10"

--- a/kotlin/hello-world-lambda/build.gradle.kts
+++ b/kotlin/hello-world-lambda/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
   mavenCentral()
 }
 
-val restateVersion = "0.6.0"
+val restateVersion = "0.7.0"
 
 dependencies {
   // Restate SDK

--- a/typescript/ecommerce-store/services/package.json
+++ b/typescript/ecommerce-store/services/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "dependencies": {
-    "@restatedev/restate-sdk": "^0.6.0",
+    "@restatedev/restate-sdk": "^0.7.0",
     "long": "^5.2.1",
     "pg": "^8.10.0",
     "pg-hstore": "^2.3.4",

--- a/typescript/food-ordering/services/package.json
+++ b/typescript/food-ordering/services/package.json
@@ -20,7 +20,7 @@
     "postbundle": "cd ../dist && zip -r index.zip index.js*"
   },
   "dependencies": {
-    "@restatedev/restate-sdk": "^0.6.0",
+    "@restatedev/restate-sdk": "^0.7.0",
     "axios": "^1.4.0"
   },
   "devDependencies": {

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -20,7 +20,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@restatedev/restate-sdk": "^0.6.0",
+                "@restatedev/restate-sdk": "^0.7.0",
                 "long": "^5.2.1",
                 "pg": "^8.10.0",
                 "pg-hstore": "^2.3.4",
@@ -42,9 +42,9 @@
             }
         },
         "ecommerce-store/services/node_modules/@restatedev/restate-sdk": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.6.0.tgz",
-            "integrity": "sha512-jh9WjGjTaGiod0rGdlEJgHkHemjz1N1i3cgXF4qhXWhUOk9iINAePxAX4FMCZVtgJm46hktfq3IdFBXl2uZLdw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.7.0.tgz",
+            "integrity": "sha512-Pxmhxq5Lfom9v9r8vEbBz3KxCVjgknt6Ej6hAsBDBg/s4jawesSdqh1rySLdqy5q0Zo0+P9YpVQtf7Q1r1FoDw==",
             "dependencies": {
                 "protobufjs": "^7.2.2",
                 "ts-proto": "^1.140.0"
@@ -70,7 +70,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@restatedev/restate-sdk": "^0.6.0",
+                "@restatedev/restate-sdk": "^0.7.0",
                 "axios": "^1.4.0"
             },
             "devDependencies": {
@@ -84,9 +84,9 @@
             }
         },
         "food-ordering/services/node_modules/@restatedev/restate-sdk": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.6.0.tgz",
-            "integrity": "sha512-jh9WjGjTaGiod0rGdlEJgHkHemjz1N1i3cgXF4qhXWhUOk9iINAePxAX4FMCZVtgJm46hktfq3IdFBXl2uZLdw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.7.0.tgz",
+            "integrity": "sha512-Pxmhxq5Lfom9v9r8vEbBz3KxCVjgknt6Ej6hAsBDBg/s4jawesSdqh1rySLdqy5q0Zo0+P9YpVQtf7Q1r1FoDw==",
             "dependencies": {
                 "protobufjs": "^7.2.2",
                 "ts-proto": "^1.140.0"
@@ -1915,6 +1915,14 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.4",
             "license": "MIT",
@@ -2252,6 +2260,28 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "dev": true,
@@ -2336,6 +2366,17 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -2730,6 +2771,41 @@
             "version": "1.4.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -3564,6 +3640,14 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+            "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "dev": true,
@@ -3624,16 +3708,17 @@
             "name": "restate-pattern-collection",
             "version": "0.0.1",
             "dependencies": {
-                "@restatedev/restate-sdk": "^0.6.0"
+                "@restatedev/restate-sdk": "^0.7.0",
+                "node-fetch": "3.3.2"
             },
             "devDependencies": {
                 "typescript": "^5.0.2"
             }
         },
         "patterns/node_modules/@restatedev/restate-sdk": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.6.0.tgz",
-            "integrity": "sha512-jh9WjGjTaGiod0rGdlEJgHkHemjz1N1i3cgXF4qhXWhUOk9iINAePxAX4FMCZVtgJm46hktfq3IdFBXl2uZLdw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.7.0.tgz",
+            "integrity": "sha512-Pxmhxq5Lfom9v9r8vEbBz3KxCVjgknt6Ej6hAsBDBg/s4jawesSdqh1rySLdqy5q0Zo0+P9YpVQtf7Q1r1FoDw==",
             "dependencies": {
                 "protobufjs": "^7.2.2",
                 "ts-proto": "^1.140.0"
@@ -3647,7 +3732,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@restatedev/restate-sdk": "^0.6.0"
+                "@restatedev/restate-sdk": "^0.7.0"
             },
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^6.4.0",
@@ -3659,9 +3744,9 @@
             }
         },
         "payment-api/node_modules/@restatedev/restate-sdk": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.6.0.tgz",
-            "integrity": "sha512-jh9WjGjTaGiod0rGdlEJgHkHemjz1N1i3cgXF4qhXWhUOk9iINAePxAX4FMCZVtgJm46hktfq3IdFBXl2uZLdw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.7.0.tgz",
+            "integrity": "sha512-Pxmhxq5Lfom9v9r8vEbBz3KxCVjgknt6Ej6hAsBDBg/s4jawesSdqh1rySLdqy5q0Zo0+P9YpVQtf7Q1r1FoDw==",
             "dependencies": {
                 "protobufjs": "^7.2.2",
                 "ts-proto": "^1.140.0"
@@ -3675,7 +3760,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@restatedev/restate-sdk": "^0.6.0",
+                "@restatedev/restate-sdk": "^0.7.0",
                 "uuid": "^9.0.0"
             },
             "devDependencies": {
@@ -3689,9 +3774,9 @@
             }
         },
         "ticket-reservation/node_modules/@restatedev/restate-sdk": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.6.0.tgz",
-            "integrity": "sha512-jh9WjGjTaGiod0rGdlEJgHkHemjz1N1i3cgXF4qhXWhUOk9iINAePxAX4FMCZVtgJm46hktfq3IdFBXl2uZLdw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-0.7.0.tgz",
+            "integrity": "sha512-Pxmhxq5Lfom9v9r8vEbBz3KxCVjgknt6Ej6hAsBDBg/s4jawesSdqh1rySLdqy5q0Zo0+P9YpVQtf7Q1r1FoDw==",
             "dependencies": {
                 "protobufjs": "^7.2.2",
                 "ts-proto": "^1.140.0"

--- a/typescript/patterns/package.json
+++ b/typescript/patterns/package.json
@@ -7,7 +7,8 @@
     "build": "tsc --noEmitOnError"
   },
   "dependencies": {
-    "@restatedev/restate-sdk": "^0.6.0"
+    "@restatedev/restate-sdk": "^0.7.0",
+    "node-fetch": "3.3.2"
   },
   "devDependencies": {
     "typescript": "^5.0.2"

--- a/typescript/patterns/src/deterministic_idempotency_tokens.ts
+++ b/typescript/patterns/src/deterministic_idempotency_tokens.ts
@@ -1,5 +1,6 @@
 import * as restate from "@restatedev/restate-sdk";
 import { randomUUID } from "crypto";
+import fetch from "node-fetch";
 
 //  -----------------                                         -----------------
 //                      Idempotency Tokens / Unique Tokens 

--- a/typescript/payment-api/package-lock.json
+++ b/typescript/payment-api/package-lock.json
@@ -4,22 +4,6 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "": {
-      "name": "@restatedev/example-payment-api",
-      "version": "0.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@restatedev/restate-sdk": "^1.0.35"
-      },
-      "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.4.0",
-        "@typescript-eslint/parser": "^6.4.0",
-        "eslint": "^8.47.0",
-        "prettier": "^3.0.1",
-        "ts-node-dev": "^2.0.0",
-        "typescript": "^5.1.6"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",

--- a/typescript/payment-api/package.json
+++ b/typescript/payment-api/package.json
@@ -16,7 +16,7 @@
     "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/payment_service.ts"
   },
   "dependencies": {
-    "@restatedev/restate-sdk": "^0.6.0"
+    "@restatedev/restate-sdk": "^0.7.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.4.0",

--- a/typescript/payment-api/src/payment_service.ts
+++ b/typescript/payment-api/src/payment_service.ts
@@ -139,7 +139,7 @@ function checkTypes(payment: Payment): Payment {
         `Type for amount (${typeof payment.amount}) cannot convert amount to number: ${
           payment.amount
         }`,
-        { cause: e }
+        { errorCode: restate.ErrorCodes.INVALID_ARGUMENT }
       );
     }
   }

--- a/typescript/ticket-reservation/package.json
+++ b/typescript/ticket-reservation/package.json
@@ -16,7 +16,7 @@
     "dev": "ts-node-dev --respawn --transpile-only ./src/app.ts"
   },
   "dependencies": {
-    "@restatedev/restate-sdk": "^0.6.0",
+    "@restatedev/restate-sdk": "^0.7.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit fixes a problem in the payment_service.ts which tried to specify a terminal error cause which is no longer supported.

Moreover, this commit adds the node-fetch dependency to the patterns because fetch seems no longer be exported by our own restate-sdk.