### PR TITLE
Update Kotlin "hello-world" CDK example to bring it in sync with TypeScript version

### DIFF
--- a/kotlin/hello-world-lambda-cdk/README.md
+++ b/kotlin/hello-world-lambda-cdk/README.md
@@ -71,7 +71,10 @@ curl --json '{}' -H "Authorization: Bearer ${RESTATE_API_TOKEN}" \
     https://${CLUSTER_ID}.dev.restate.cloud:8080/greeter.Greeter/Greet
 ```
 
-### Useful commands
+## Cleanup
 
-* `npm run build`   compile the Lambda handler and synthesize CDK deployment artifacts
-* `npm run deploy`  perform a CDK deployment
+To tear down the stack, run:
+
+```shell
+npm run destroy
+```

--- a/kotlin/hello-world-lambda-cdk/bin/lambda-jvm-cdk.ts
+++ b/kotlin/hello-world-lambda-cdk/bin/lambda-jvm-cdk.ts
@@ -5,6 +5,7 @@ import { LambdaJvmCdkStack } from "../cdk/lambda-jvm-cdk-stack";
 
 const app = new cdk.App();
 new LambdaJvmCdkStack(app, "LambdaJvmCdkStack", {
+  selfHosted: Boolean(app.node.tryGetContext("selfHosted")),
   clusterId: app.node.getContext("clusterId"),
   authTokenSecretArn: app.node.getContext("authTokenSecretArn"),
 });

--- a/kotlin/hello-world-lambda-cdk/package.json
+++ b/kotlin/hello-world-lambda-cdk/package.json
@@ -12,7 +12,8 @@
     "watch": "tsc -w",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "verify": "npm run format -- --check && npm run lint && npm run build",
-    "deploy": "npm run build && cdk deploy"
+    "deploy": "npm run build && cdk deploy",
+    "destroy": "npx cdk destroy"
   },
   "devDependencies": {
     "@restatedev/restate-cdk": "^0.7.0",

--- a/typescript/hello-world-lambda-cdk/README.md
+++ b/typescript/hello-world-lambda-cdk/README.md
@@ -70,7 +70,10 @@ curl -H "Authorization: Bearer ${RESTATE_API_TOKEN}" \
     https://${CLUSTER_ID}.dev.restate.cloud:8080/Greeter/greet
 ```
 
-### Useful commands
+## Cleanup
 
-* `npm run build`   compile the Lambda handler and synthesize CDK deployment artifacts
-* `npm run deploy`  perform a CDK deployment
+To tear down the stack, run:
+
+```shell
+npm run destroy
+```

--- a/typescript/hello-world-lambda-cdk/package.json
+++ b/typescript/hello-world-lambda-cdk/package.json
@@ -9,7 +9,8 @@
     "build": "npx cdk synth",
     "format": "prettier --ignore-path .eslintignore --write \"**/*.+(js|ts|json)\"",
     "verify": "npm run format -- --check && npm run lint && npm run build",
-    "deploy": "npm run build && lib deploy"
+    "deploy": "npm run build && lib deploy",
+    "destroy": "npx cdk destroy"
   },
   "devDependencies": {
     "@restatedev/restate-cdk": "^0.7.0",


### PR DESCRIPTION
- adds the option of a self-hosted EC2-based Restate environment as a context parameter
- adds a `destroy` script and cleanup instructions to both the "hello world" CDK examples (TS & Kt)