### PR TITLE
Make readme's easier to navigate and read

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,107 +7,32 @@
 Browse this repository to see how easy distributed applications development becomes with Restate.
 
 ## Starters
-
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
-
-[Hello world on AWS Lambda](typescript/hello-world-lambda)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda.zip && unzip typescript-hello-world-lambda.zip -d typescript-hello-world-lambda && rm typescript-hello-world-lambda.zip
-```
-
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
-
-[Hello world on AWS Lambda + CDK](typescript/hello-world-lambda-cdk)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda-cdk.zip && unzip typescript-hello-world-lambda-cdk.zip -d typescript-hello-world-lambda-cdk && rm typescript-hello-world-lambda-cdk.zip
-```
-
-![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)
-
-[Hello World HTTP](java/hello-world-http)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/java-hello-world-http.zip && unzip java-hello-world-http.zip -d java-hello-world-http && rm java-hello-world-http.zip
-```
-
-[Hello world on AWS Lambda](java/hello-world-lambda)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/java-hello-world-lambda.zip && unzip java-hello-world-lambda.zip -d java-hello-world-lambda && rm java-hello-world-lambda.zip
-```
-
-![Kotlin](https://img.shields.io/badge/kotlin-%237F52FF.svg?style=for-the-badge&logo=kotlin&logoColor=white)
-
-[Hello World HTTP](kotlin/hello-world-http)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-http.zip && unzip kotlin-hello-world-http.zip -d kotlin-hello-world-http && rm kotlin-hello-world-http.zip
-```
-
-[Hello world on AWS Lambda](kotlin/hello-world-lambda)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-lambda.zip && unzip kotlin-hello-world-lambda.zip -d kotlin-hello-world-lambda && rm kotlin-hello-world-lambda.zip
-```
-
-[Hello world on AWS Lambda + CDK](kotlin/hello-world-lambda-cdk)
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-lambda-cdk.zip && unzip kotlin-hello-world-lambda-cdk.zip -d kotlin-hello-world-lambda-cdk && rm kotlin-hello-world-lambda-cdk.zip
-```
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| TypeScript| [Hello world on AWS Lambda](typescript/hello-world-lambda)       |
+| TypeScript| [Hello world on AWS Lambda + CDK](typescript/hello-world-lambda-cdk) |
+| Java      | [Hello World HTTP](java/hello-world-http)                       |
+| Java      | [Hello world on AWS Lambda](java/hello-world-lambda)             |
+| Kotlin    | [Hello World HTTP](kotlin/hello-world-http)                     |
+| Kotlin    | [Hello world on AWS Lambda](kotlin/hello-world-lambda)           |
+| Kotlin    | [Hello world on AWS Lambda + CDK](kotlin/hello-world-lambda-cdk) |
 
 ## Patterns
 
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
-
-[Payment api](typescript/payment-api): Example API for payments, inspired by the Stripe API
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-payment-api.zip && unzip typescript-payment-api.zip -d typescript-payment-api && rm typescript-payment-api.zip
-```
-
-[End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-end-to-end-testing.zip && unzip typescript-end-to-end-testing.zip -d typescript-end-to-end-testing && rm typescript-end-to-end-testing.zip
-```
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| TypeScript| [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API |
+| TypeScript| [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end |
 
 ## Applications
 
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
-
-[Food ordering - TypeScript](typescript/food-ordering): Integrate Restate with external services
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-food-ordering.zip && unzip typescript-food-ordering.zip -d typescript-food-ordering && rm typescript-food-ordering.zip
-```
-
-[Ticket reservation](typescript/ticket-reservation): Example showing Restate's keyed-sharding and concurrency guarantees
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-ticket-reservation.zip && unzip typescript-ticket-reservation.zip -d typescript-ticket-reservation && rm typescript-ticket-reservation.zip
-```
-
-[Ecommerce store](typescript/ecommerce-store): An ecommerce store completely built on top of Restate
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-ecommerce-store.zip && unzip typescript-ecommerce-store.zip -d typescript-ecommerce-store && rm typescript-ecommerce-store.zip
-```
-
-[Dynamic workflow executor](typescript/dynamic-workflow-executor): A workflow executor that dynamically executes a list of steps as specified in the JSON input.
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-dynamic-workflow-executor.zip && unzip typescript-dynamic-workflow-executor.zip -d typescript-dynamic-workflow-executor && rm typescript-dynamic-workflow-executor.zip
-```
-
-![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)
-
-[Food ordering - Java](java/food-ordering): Java food order processing app and driver-to-delivery matching services.
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/java-food-ordering.zip && unzip java-food-ordering.zip -d java-food-ordering && rm java-food-ordering.zip
-```
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| TypeScript| [Food ordering - TypeScript](typescript/food-ordering): Integrate Restate with external services |
+| TypeScript| [Ticket reservation](typescript/ticket-reservation): Example showing Restate's keyed-sharding and concurrency guarantees |
+| TypeScript| [Ecommerce store](typescript/ecommerce-store): An ecommerce store completely built on top of Restate |
+| TypeScript| [Dynamic workflow executor](typescript/dynamic-workflow-executor): A workflow executor that dynamically executes a list of steps as specified in the JSON input |
+| Java      | [Food ordering - Java](java/food-ordering): Java food order processing app and driver-to-delivery matching services |
 
 
 ## Joining the community

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Browse this repository to see how easy distributed applications development beco
 
 ## Patterns
 
-| Language  | Name / Link                                                                                                          |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
-| TypeScript| [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API                          |
-| TypeScript| [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end              |
-| TypeScript| [Common patterns](typescript/patterns) Set of common patterns you encounter when developing distributed applications |
+| Language   | Name / Link                                                                                                             |
+|------------|-------------------------------------------------------------------------------------------------------------------------|
+| TypeScript | [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API                             |
+| TypeScript | [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end                 |
+| TypeScript | [Common patterns](typescript/patterns) Set of common patterns you encounter when developing distributed TS applications |
+| Java       | [Common patterns](java/patterns) Set of common patterns you encounter when developing distributed Java applications     |
 
 
 ## Applications

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Browse this repository to see how easy distributed applications development beco
 
 ## Patterns
 
-| Language  | Name / Link                                                     |
-|-----------|-----------------------------------------------------------------|
-| TypeScript| [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API |
-| TypeScript| [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end |
+| Language  | Name / Link                                                                                                          |
+|-----------|----------------------------------------------------------------------------------------------------------------------|
+| TypeScript| [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API                          |
+| TypeScript| [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end              |
+| TypeScript| [Common patterns](typescript/patterns) Set of common patterns you encounter when developing distributed applications |
+
 
 ## Applications
 

--- a/java/README.md
+++ b/java/README.md
@@ -2,14 +2,21 @@
 
 This directory contains Restate examples using the Java SDK.
 
-## Common patterns
+## Starters
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| Java      | [Hello World HTTP](hello-world-http)                       |
+| Java      | [Hello world on AWS Lambda](hello-world-lambda)             |
 
-- A collection of [common patterns](patterns) you encounter when developing distributed applications.
+## Patterns
 
-## Starter examples
+| Language   | Name / Link                                                                                                             |
+|------------|-------------------------------------------------------------------------------------------------------------------------|
+| Java       | [Common patterns](patterns) Set of common patterns you encounter when developing distributed Java applications     |
 
-- [Hello World](hello-world-http): A simple example of a Restate service.
-- [Hello World - AWS Lambda](hello-world-lambda): A simple example of how you can run a Restate service on AWS Lambda.
 
 ## Applications
-- [Food ordering](food-ordering): See how to integrate Restate with external services using Awakeables and side effects.
+
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| Java      | [Food ordering - Java](food-ordering): Java food order processing app and driver-to-delivery matching services |

--- a/java/food-ordering/README.md
+++ b/java/food-ordering/README.md
@@ -8,7 +8,24 @@ It also interacts with the delivery services to get the order delivered to the c
 
 ![demo_overview.png](demo_overview.png)
 
+## Download the example
 
+- Via the CLI:
+    ```shell
+    restate example java-food-ordering && cd java-food-ordering
+    ```
+
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/java/food-ordering
+    ```
+
+- Via `wget`:
+    ```shell
+   wget https://github.com/restatedev/examples/releases/latest/download/java-food-ordering.zip && unzip java-food-ordering.zip -d java-food-ordering && rm java-food-ordering.zip
+    ```
+  
 ## Running locally with Docker compose
 
 Build the docker containers:

--- a/java/hello-world-http/README.md
+++ b/java/hello-world-http/README.md
@@ -10,9 +10,21 @@ Sample project configuration of a Restate service using the Java interface and H
 
 ## Download the example
 
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/java-hello-world-http.zip && unzip java-hello-world-http.zip -d java-hello-world-http && rm java-hello-world-http.zip
-```
+- Via the CLI:
+    ```shell
+    restate example java-hello-world-http && cd java-hello-world-http
+    ```
+
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/java/hello-world-http
+    ```
+
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/java-hello-world-http.zip && unzip java-hello-world-http.zip -d java-hello-world-http && rm java-hello-world-http.zip
+    ```
 
 ## Running the example
 

--- a/java/hello-world-lambda/README.md
+++ b/java/hello-world-lambda/README.md
@@ -10,10 +10,21 @@ Sample project configuration of a Restate service using the Java interface and A
 * [Logging configuration](src/main/resources/log4j2.properties)
 
 ## Download the example
+- Via the CLI:
+    ```shell
+    restate example java-hello-world-lambda && cd java-hello-world-lambda
+    ```
 
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/java-hello-world-lambda.zip && unzip java-hello-world-lambda.zip -d java-hello-world-lambda && rm java-hello-world-lambda.zip
-```
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/java/hello-world-lambda
+    ```
+
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/java-hello-world-lambda.zip && unzip java-hello-world-lambda.zip -d java-hello-world-lambda && rm java-hello-world-lambda.zip
+    ```
 
 ## Package
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,10 @@
+# Kotlin examples
+
+This directory contains Restate examples using the Kotlin SDK.
+
+## Starters
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| Kotlin    | [Hello World HTTP](hello-world-http)                     |
+| Kotlin    | [Hello world on AWS Lambda](hello-world-lambda)           |
+| Kotlin    | [Hello world on AWS Lambda + CDK](hello-world-lambda-cdk) |

--- a/kotlin/hello-world-http/README.md
+++ b/kotlin/hello-world-http/README.md
@@ -10,9 +10,21 @@ Sample project configuration of a Restate service using the Kotlin coroutines in
 
 ## Download the example
 
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-http.zip && unzip kotlin-hello-world-http.zip -d kotlin-hello-world-http && rm kotlin-hello-world-http.zip
-```
+- Via the CLI:
+    ```shell
+    restate example kotlin-hello-world-http && cd kotlin-hello-world-http
+    ```
+
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/kotlin/hello-world-http
+    ```
+
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-http.zip && unzip kotlin-hello-world-http.zip -d kotlin-hello-world-http && rm kotlin-hello-world-http.zip
+    ```
 
 ## Running the example
 

--- a/kotlin/hello-world-lambda-cdk/README.md
+++ b/kotlin/hello-world-lambda-cdk/README.md
@@ -12,9 +12,21 @@ For more information on CDK, please see [Getting started with the AWS CDK](https
 
 ## Download the example
 
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-lambda-cdk.zip && unzip kotlin-hello-world-lambda-cdk.zip -d kotlin-hello-world-lambda-cdk && rm kotlin-hello-world-lambda-cdk.zip
-```
+- Via the CLI:
+    ```shell
+    restate example kotlin-hello-world-lambda-cdk && cd kotlin-hello-world-lambda-cdk
+    ```
+
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/kotlin/hello-world-lambda-cdk
+    ```
+
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-lambda-cdk.zip && unzip kotlin-hello-world-lambda-cdk.zip -d kotlin-hello-world-lambda-cdk && rm kotlin-hello-world-lambda-cdk.zip
+    ```
 
 ## Deploy
 

--- a/kotlin/hello-world-lambda/README.md
+++ b/kotlin/hello-world-lambda/README.md
@@ -11,9 +11,21 @@ Sample project configuration of a Restate service using the Kotlin coroutines in
 
 ## Download the example
 
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-lambda.zip && unzip kotlin-hello-world-lambda.zip -d kotlin-hello-world-lambda && rm kotlin-hello-world-lambda.zip
-```
+- Via the CLI:
+    ```shell
+    restate example kotlin-hello-world-lambda && cd kotlin-hello-world-lambda
+    ```
+
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/kotlin/hello-world-lambda
+    ```
+
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/kotlin-hello-world-lambda.zip && unzip kotlin-hello-world-lambda.zip -d kotlin-hello-world-lambda && rm kotlin-hello-world-lambda.zip
+    ```
 
 ## Package
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -10,11 +10,11 @@ This directory contains Restate examples using the Typescript SDK.
 
 ## Patterns
 
-| Language  | Name / Link                                                                                                          |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
-| TypeScript| [Payment API](payment-api): Example API for payments, inspired by the Stripe API                          |
-| TypeScript| [End-to-end testing](end-to-end-testing): Example of how to test Restate services end-to-end              |
-| TypeScript| [Common patterns](patterns) Set of common patterns you encounter when developing distributed applications |
+| Language  | Name / Link                                                                                                  |
+|-----------|--------------------------------------------------------------------------------------------------------------|
+| TypeScript| [Payment API](payment-api): Example API for payments, inspired by the Stripe API                             |
+| TypeScript| [End-to-end testing](end-to-end-testing): Example of how to test Restate services end-to-end                 |
+| TypeScript| [Common patterns](patterns) Set of common patterns you encounter when developing distributed TS applications |
 
 
 ## Applications

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -5,23 +5,23 @@ This directory contains Restate examples using the Typescript SDK.
 ## Starters
 | Language  | Name / Link                                                     |
 |-----------|-----------------------------------------------------------------|
-| TypeScript| [Hello world on AWS Lambda](typescript/hello-world-lambda)       |
-| TypeScript| [Hello world on AWS Lambda + CDK](typescript/hello-world-lambda-cdk) |
+| TypeScript| [Hello world on AWS Lambda](hello-world-lambda)       |
+| TypeScript| [Hello world on AWS Lambda + CDK](hello-world-lambda-cdk) |
 
 ## Patterns
 
 | Language  | Name / Link                                                                                                          |
 |-----------|----------------------------------------------------------------------------------------------------------------------|
-| TypeScript| [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API                          |
-| TypeScript| [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end              |
-| TypeScript| [Common patterns](typescript/patterns) Set of common patterns you encounter when developing distributed applications |
+| TypeScript| [Payment API](payment-api): Example API for payments, inspired by the Stripe API                          |
+| TypeScript| [End-to-end testing](end-to-end-testing): Example of how to test Restate services end-to-end              |
+| TypeScript| [Common patterns](patterns) Set of common patterns you encounter when developing distributed applications |
 
 
 ## Applications
 
 | Language  | Name / Link                                                     |
 |-----------|-----------------------------------------------------------------|
-| TypeScript| [Food ordering - TypeScript](typescript/food-ordering): Integrate Restate with external services |
-| TypeScript| [Ticket reservation](typescript/ticket-reservation): Example showing Restate's keyed-sharding and concurrency guarantees |
-| TypeScript| [Ecommerce store](typescript/ecommerce-store): An ecommerce store completely built on top of Restate |
-| TypeScript| [Dynamic workflow executor](typescript/dynamic-workflow-executor): A workflow executor that dynamically executes a list of steps as specified in the JSON input |
+| TypeScript| [Food ordering - TypeScript](food-ordering): Integrate Restate with external services |
+| TypeScript| [Ticket reservation](ticket-reservation): Example showing Restate's keyed-sharding and concurrency guarantees |
+| TypeScript| [Ecommerce store](ecommerce-store): An ecommerce store completely built on top of Restate |
+| TypeScript| [Dynamic workflow executor](dynamic-workflow-executor): A workflow executor that dynamically executes a list of steps as specified in the JSON input |

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,21 +2,26 @@
 
 This directory contains Restate examples using the Typescript SDK.
 
-## Common patterns
+## Starters
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| TypeScript| [Hello world on AWS Lambda](typescript/hello-world-lambda)       |
+| TypeScript| [Hello world on AWS Lambda + CDK](typescript/hello-world-lambda-cdk) |
 
-- A collection of [common patterns](patterns) you encounter when developing distributed applications.
+## Patterns
 
-## Starter examples
+| Language  | Name / Link                                                                                                          |
+|-----------|----------------------------------------------------------------------------------------------------------------------|
+| TypeScript| [Payment API](typescript/payment-api): Example API for payments, inspired by the Stripe API                          |
+| TypeScript| [End-to-end testing](typescript/end-to-end-testing): Example of how to test Restate services end-to-end              |
+| TypeScript| [Common patterns](typescript/patterns) Set of common patterns you encounter when developing distributed applications |
 
-- [Hello World - AWS Lambda](hello-world-lambda): A simple example of how you can run a Restate service on AWS Lambda.
-- [Hello World - AWS Lambda & CDK](hello-world-lambda-cdk): A simple example of automating deployment to AWS Lambda using CDK.
-- [Payment api](payment-api/): Example API for payments, inspired by the Stripe API.
-- [Food ordering](food-ordering): See how to integrate Restate with external services using Awakeables and side effects.
 
-## Intermediate examples
+## Applications
 
-- [Ticket reservation](ticket-reservation): An example to illustrate how Restate's keyed-sharding and concurrency guarantees simplify microservice architectures.
-
-## Advanced examples
-
-- [Ecommerce store](ecommerce-store): A sophisticated example on how to build an ecommerce store based on Restate using the grpc-based Typescript SDK.
+| Language  | Name / Link                                                     |
+|-----------|-----------------------------------------------------------------|
+| TypeScript| [Food ordering - TypeScript](typescript/food-ordering): Integrate Restate with external services |
+| TypeScript| [Ticket reservation](typescript/ticket-reservation): Example showing Restate's keyed-sharding and concurrency guarantees |
+| TypeScript| [Ecommerce store](typescript/ecommerce-store): An ecommerce store completely built on top of Restate |
+| TypeScript| [Dynamic workflow executor](typescript/dynamic-workflow-executor): A workflow executor that dynamically executes a list of steps as specified in the JSON input |

--- a/typescript/dynamic-workflow-executor/README.md
+++ b/typescript/dynamic-workflow-executor/README.md
@@ -24,6 +24,25 @@ Here is an overview of the services:
 **Note:** This app stores images locally in the shared locally accessible folder `generated-images`.
 In a real deployment, this would need to be a shared storage, like S3.
 
+## Download the example
+
+Via the CLI:
+```shell
+restate example typescript-ecommerce-store && cd typescript-dynamic-workflow-executor
+```
+
+Or  clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/dynamic-workflow-executor
+```
+
+Or download the example with `wget`:
+```shell
+wget https://github.com/restatedev/examples/releases/latest/download/typescript-dynamic-workflow-executor.zip && unzip typescript-dynamic-workflow-executor.zip -d typescript-dynamic-workflow-executor && rm typescript-dynamic-workflow-executor.zip
+```
+
 ## Running the example
 
 ### Deploy Restate Server

--- a/typescript/dynamic-workflow-executor/README.md
+++ b/typescript/dynamic-workflow-executor/README.md
@@ -28,7 +28,7 @@ In a real deployment, this would need to be a shared storage, like S3.
 
 - Via the CLI:
     ```shell
-    restate example typescript-ecommerce-store && cd typescript-dynamic-workflow-executor
+    restate example typescript-dynamic-workflow-executor && cd typescript-dynamic-workflow-executor
     ```
 
 - Via git clone:

--- a/typescript/dynamic-workflow-executor/README.md
+++ b/typescript/dynamic-workflow-executor/README.md
@@ -26,22 +26,21 @@ In a real deployment, this would need to be a shared storage, like S3.
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-ecommerce-store && cd typescript-dynamic-workflow-executor
-```
+- Via the CLI:
+    ```shell
+    restate example typescript-ecommerce-store && cd typescript-dynamic-workflow-executor
+    ```
 
-Or  clone the entire git repo:
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/typescript/dynamic-workflow-executor
+    ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/dynamic-workflow-executor
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-dynamic-workflow-executor.zip && unzip typescript-dynamic-workflow-executor.zip -d typescript-dynamic-workflow-executor && rm typescript-dynamic-workflow-executor.zip
-```
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/typescript-dynamic-workflow-executor.zip && unzip typescript-dynamic-workflow-executor.zip -d typescript-dynamic-workflow-executor && rm typescript-dynamic-workflow-executor.zip
+    ```
 
 ## Running the example
 

--- a/typescript/ecommerce-store/README.md
+++ b/typescript/ecommerce-store/README.md
@@ -17,23 +17,21 @@ Restate is a system for easily building resilient applications using **distribut
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-ecommerce-store && cd typescript-ecommerce-store
-```
+- Via the CLI:
+    ```shell
+    restate example typescript-ecommerce-store && cd typescript-ecommerce-store
+    ```
 
-Or clone the entire git repo:
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/typescript/ecommerce-store
+    ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/ecommerce-store
-```
-
-Or download the example with `wget`:
-```shell
-# Download the example
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-ecommerce-store.zip && unzip typescript-ecommerce-store.zip -d typescript-ecommerce-store && rm typescript-ecommerce-store.zip
-```
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/typescript-ecommerce-store.zip && unzip typescript-ecommerce-store.zip -d typescript-ecommerce-store && rm typescript-ecommerce-store.zip
+    ```
 
 
 ## Deployment on Docker Compose

--- a/typescript/ecommerce-store/README.md
+++ b/typescript/ecommerce-store/README.md
@@ -17,9 +17,24 @@ Restate is a system for easily building resilient applications using **distribut
 
 ## Download the example
 
+Via the CLI:
 ```shell
+restate example typescript-ecommerce-store && cd typescript-ecommerce-store
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/ecommerce-store
+```
+
+Or download the example with `wget`:
+```shell
+# Download the example
 wget https://github.com/restatedev/examples/releases/latest/download/typescript-ecommerce-store.zip && unzip typescript-ecommerce-store.zip -d typescript-ecommerce-store && rm typescript-ecommerce-store.zip
 ```
+
 
 ## Deployment on Docker Compose
 

--- a/typescript/end-to-end-testing/README.md
+++ b/typescript/end-to-end-testing/README.md
@@ -6,6 +6,19 @@ This example shows how to test Restate services by deploying Restate with [TestC
 
 ## Download the example
 
+Via the CLI:
+```shell
+restate example typescript-end-to-end-testing && cd typescript-end-to-end-testing
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/end-to-end-testing
+```
+
+Or download the example with `wget`:
 ```shell
 wget https://github.com/restatedev/examples/releases/latest/download/typescript-end-to-end-testing.zip && unzip typescript-end-to-end-testing.zip -d typescript-end-to-end-testing && rm typescript-end-to-end-testing.zip
 ```

--- a/typescript/end-to-end-testing/README.md
+++ b/typescript/end-to-end-testing/README.md
@@ -6,22 +6,21 @@ This example shows how to test Restate services by deploying Restate with [TestC
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-end-to-end-testing && cd typescript-end-to-end-testing
-```
+- Via the CLI:
+    ```shell
+    restate example typescript-end-to-end-testing && cd typescript-end-to-end-testing
+    ```
 
-Or clone the entire git repo:
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/typescript/end-to-end-testing
+    ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/end-to-end-testing
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-end-to-end-testing.zip && unzip typescript-end-to-end-testing.zip -d typescript-end-to-end-testing && rm typescript-end-to-end-testing.zip
-```
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/typescript-end-to-end-testing.zip && unzip typescript-end-to-end-testing.zip -d typescript-end-to-end-testing && rm typescript-end-to-end-testing.zip
+    ```
 
 ## Run
 

--- a/typescript/food-ordering/README.md
+++ b/typescript/food-ordering/README.md
@@ -13,6 +13,26 @@ It also interacts with the delivery services to get the order delivered to the c
 
 The app logic (order workflow) discussed in the presentation can be found under: `app/src/restate-app/services/order_workflow.ts`.
 
+## Download the example
+
+Via the CLI:
+```shell
+restate example typescript-food-ordering && cd typescript-food-ordering
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/food-ordering
+```
+
+Or download the example with `wget`:
+```shell
+wget https://github.com/restatedev/examples/releases/latest/download/typescript-food-ordering.zip && unzip typescript-food-ordering.zip -d typescript-food-ordering && rm typescript-food-ordering.zip
+```
+
+
 ## Running locally with Docker compose
 
 Launch the Docker compose setup:

--- a/typescript/food-ordering/README.md
+++ b/typescript/food-ordering/README.md
@@ -15,22 +15,21 @@ The app logic (order workflow) discussed in the presentation can be found under:
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-food-ordering && cd typescript-food-ordering
-```
+- Via the CLI:
+   ```shell
+   restate example typescript-food-ordering && cd typescript-food-ordering
+   ```
 
-Or clone the entire git repo:
+- Via git clone:
+   ```shell
+   git clone git@github.com:restatedev/examples.git
+   cd examples/typescript/food-ordering
+   ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/food-ordering
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-food-ordering.zip && unzip typescript-food-ordering.zip -d typescript-food-ordering && rm typescript-food-ordering.zip
-```
+- Via `wget`:
+   ```shell
+   wget https://github.com/restatedev/examples/releases/latest/download/typescript-food-ordering.zip && unzip typescript-food-ordering.zip -d typescript-food-ordering && rm typescript-food-ordering.zip
+   ```
 
 
 ## Running locally with Docker compose

--- a/typescript/hello-world-lambda-cdk/README.md
+++ b/typescript/hello-world-lambda-cdk/README.md
@@ -12,22 +12,21 @@ For more information on CDK, please see [Getting started with the AWS CDK](https
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-hello-world-lambda-cdk && cd typescript-hello-world-lambda-cdk
-```
+- Via the CLI:
+    ```shell
+    restate example typescript-hello-world-lambda-cdk && cd typescript-hello-world-lambda-cdk
+    ```
 
-Or clone the entire git repo:
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/typescript/hello-world-lambda-cdk
+    ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/hello-world-lambda-cdk
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda-cdk.zip && unzip typescript-hello-world-lambda-cdk.zip -d typescript-hello-world-lambda-cdk && rm typescript-hello-world-lambda-cdk.zip
-```
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda-cdk.zip && unzip typescript-hello-world-lambda-cdk.zip -d typescript-hello-world-lambda-cdk && rm typescript-hello-world-lambda-cdk.zip
+    ```
 
 ## Deploy
 

--- a/typescript/hello-world-lambda-cdk/README.md
+++ b/typescript/hello-world-lambda-cdk/README.md
@@ -12,6 +12,19 @@ For more information on CDK, please see [Getting started with the AWS CDK](https
 
 ## Download the example
 
+Via the CLI:
+```shell
+restate example typescript-hello-world-lambda-cdk && cd typescript-hello-world-lambda-cdk
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/hello-world-lambda-cdk
+```
+
+Or download the example with `wget`:
 ```shell
 wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda-cdk.zip && unzip typescript-hello-world-lambda-cdk.zip -d typescript-hello-world-lambda-cdk && rm typescript-hello-world-lambda-cdk.zip
 ```

--- a/typescript/hello-world-lambda/README.md
+++ b/typescript/hello-world-lambda/README.md
@@ -8,19 +8,18 @@ for a walk through guide to deploying this service.
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-hello-world-lambda && cd typescript-hello-world-lambda
-```
+- Via the CLI:
+    ```shell
+    restate example typescript-hello-world-lambda && cd typescript-hello-world-lambda
+    ```
 
-Or clone the entire git repo:
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/typescript/hello-world-lambda
+    ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/hello-world-lambda
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda.zip && unzip typescript-hello-world-lambda.zip -d typescript-hello-world-lambda && rm typescript-hello-world-lambda.zip
-```
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda.zip && unzip typescript-hello-world-lambda.zip -d typescript-hello-world-lambda && rm typescript-hello-world-lambda.zip
+    ```

--- a/typescript/hello-world-lambda/README.md
+++ b/typescript/hello-world-lambda/README.md
@@ -8,6 +8,19 @@ for a walk through guide to deploying this service.
 
 ## Download the example
 
+Via the CLI:
+```shell
+restate example typescript-hello-world-lambda && cd typescript-hello-world-lambda
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/hello-world-lambda
+```
+
+Or download the example with `wget`:
 ```shell
 wget https://github.com/restatedev/examples/releases/latest/download/typescript-hello-world-lambda.zip && unzip typescript-hello-world-lambda.zip -d typescript-hello-world-lambda && rm typescript-hello-world-lambda.zip
 ```

--- a/typescript/patterns/README.md
+++ b/typescript/patterns/README.md
@@ -4,9 +4,6 @@ A collections of useful patterns in distributed applications, and how to
 implement them with [Restate](https://github.com/restatedev/).
 This is a continuously evolving list.
 
-The patterns currently exist only in TypeScript/JavaScript, other languages
-will be added soon.
-
 All patterns are described in one file and have a comment block at the top
 that explains them.
 

--- a/typescript/payment-api/README.md
+++ b/typescript/payment-api/README.md
@@ -22,22 +22,21 @@ and failures.
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-payment-api && cd typescript-payment-api
-```
+- Via the CLI:
+  ```shell
+  restate example typescript-payment-api && cd typescript-payment-api
+  ```
 
-Or clone the entire git repo:
+- Via git clone:
+  ```shell
+  git clone git@github.com:restatedev/examples.git
+  cd examples/typescript/payment-api
+  ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/payment-api
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-payment-api.zip && unzip typescript-payment-api.zip -d typescript-payment-api && rm typescript-payment-api.zip
-```
+- Via `wget`:
+  ```shell
+  wget https://github.com/restatedev/examples/releases/latest/download/typescript-payment-api.zip && unzip typescript-payment-api.zip -d typescript-payment-api && rm typescript-payment-api.zip
+  ```
 
 ## Running this example
 

--- a/typescript/payment-api/README.md
+++ b/typescript/payment-api/README.md
@@ -22,6 +22,19 @@ and failures.
 
 ## Download the example
 
+Via the CLI:
+```shell
+restate example typescript-payment-api && cd typescript-payment-api
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/payment-api
+```
+
+Or download the example with `wget`:
 ```shell
 wget https://github.com/restatedev/examples/releases/latest/download/typescript-payment-api.zip && unzip typescript-payment-api.zip -d typescript-payment-api && rm typescript-payment-api.zip
 ```

--- a/typescript/ticket-reservation/README.md
+++ b/typescript/ticket-reservation/README.md
@@ -8,9 +8,23 @@ Restate is a system for easily building resilient applications using **distribut
 
 ## Download the example
 
+Via the CLI:
+```shell
+restate example typescript-ticket-reservation && cd typescript-ticket-reservation
+```
+
+Or clone the entire git repo:
+
+```shell
+git clone git@github.com:restatedev/examples.git
+cd examples/typescript/ticket-reservation
+```
+
+Or download the example with `wget`:
 ```shell
 wget https://github.com/restatedev/examples/releases/latest/download/typescript-ticket-reservation.zip && unzip typescript-ticket-reservation.zip -d typescript-ticket-reservation && rm typescript-ticket-reservation.zip
 ```
+
 
 ## Quickstart
 

--- a/typescript/ticket-reservation/README.md
+++ b/typescript/ticket-reservation/README.md
@@ -8,22 +8,21 @@ Restate is a system for easily building resilient applications using **distribut
 
 ## Download the example
 
-Via the CLI:
-```shell
-restate example typescript-ticket-reservation && cd typescript-ticket-reservation
-```
+- Via the CLI:
+    ```shell
+    restate example typescript-ticket-reservation && cd typescript-ticket-reservation
+    ```
 
-Or clone the entire git repo:
+- Via git clone:
+    ```shell
+    git clone git@github.com:restatedev/examples.git
+    cd examples/typescript/ticket-reservation
+    ```
 
-```shell
-git clone git@github.com:restatedev/examples.git
-cd examples/typescript/ticket-reservation
-```
-
-Or download the example with `wget`:
-```shell
-wget https://github.com/restatedev/examples/releases/latest/download/typescript-ticket-reservation.zip && unzip typescript-ticket-reservation.zip -d typescript-ticket-reservation && rm typescript-ticket-reservation.zip
-```
+- Via `wget`:
+    ```shell
+    wget https://github.com/restatedev/examples/releases/latest/download/typescript-ticket-reservation.zip && unzip typescript-ticket-reservation.zip -d typescript-ticket-reservation && rm typescript-ticket-reservation.zip
+    ```
 
 
 ## Quickstart


### PR DESCRIPTION
Fixes #70 
- Give main readme a table structure
- Move download commands to the examples and add CLI and git clone versions
- Add kotlin readme

**NOTE** There are a few examples that do not have a zip yet and are not yet downloadable via the CLI because they were added after the last release.