### PR TITLE
Cleanup: Unify MacOS and Linux Docker commands, use CLI for registration, terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,52 +45,58 @@ The Discord server is also the perfect place for sharing your feedback with us, 
 
 ## Running the examples
 
-The readme for each example will explain how to get it running. Once the example is running, it needs to be discovered by an instance of the Restate runtime.
+The readme for each example will explain how to get it running. Once the services of the example are running, the deployment needs to be registered in Restate.
 
-### Launching the runtime
+### Launching the Restate Server
 
-Have a look at how to start up the runtime in a Docker container in [this repository]* or run the following commands:
+**NOTE:** Some examples can be run with Docker Compose. For those, you can ignore this section.
 
-- For MacOS:
-```shell
-docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 docker.io/restatedev/restate:latest
-```
-- For Linux:
-```shell
-docker run --name restate_dev --rm --network=host docker.io/restatedev/restate:latest
-```
+For running Restate locally and downloading the binaries, have a look at the options on the [`Get Restate` page](https://restate.dev/get-restate/).
 
-### Connect runtime and services
+- To run Restate in a Docker container:
+    ```shell
+    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:latest
+    ```
+- To run Restate with `npx`:
+    ```shell
+    npx @restatedev/restate-server@latest
+    ```
+- To run Restate with Homebrew:
+    ```
+    brew install restatedev/tap/restate-server
+    ```
 
-Once the runtime is up, let it discover the services of the example by executing:
+### Register the deployment in Restate
 
-- For MacOS:
-```shell
-curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
-```
-- For Linux:
-```shell
-curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
-```
+Once Restate is up, register the deployment in Restate by executing:
+
+- Via the [CLI](https://docs.restate.dev/restate/cli):
+    ```shell
+    restate dp register http://host.docker.internal:9080
+    ```
+- Via `curl`:
+    ```shell
+    curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
+    ```
 
 This should give you the following output in case of the ticket reservation example:
 ```json
 {
-    "id": "bG9jYWxob3N0OjgwODAv",
-    "services": [
-        {
-            "name": "UserSession",
-            "revision": 1
-        },
-        {
-            "name": "TicketDb",
-            "revision": 1
-        },
-        {
-            "name": "CheckoutProcess",
-            "revision": 1
-        }
-    ]
+  "id": "bG9jYWxob3N0OjgwODAv",
+  "services": [
+    {
+      "name": "UserSession",
+      "revision": 1
+    },
+    {
+      "name": "TicketDb",
+      "revision": 1
+    },
+    {
+      "name": "CheckoutProcess",
+      "revision": 1
+    }
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ Once Restate is up, register the deployment in Restate by executing:
     ```shell
     restate dp register http://host.docker.internal:9080
     ```
+  When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
 - Via `curl`:
     ```shell
     curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
     ```
+  When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
 
 This should give you the following output in case of the ticket reservation example:
 ```json

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For running Restate locally and downloading the binaries, have a look at the opt
 - To run Restate with Homebrew:
     ```
     brew install restatedev/tap/restate-server
+    restate-server 
     ```
 
 ### Register the deployment in Restate
@@ -72,14 +73,14 @@ Once Restate is up, register the deployment in Restate by executing:
 
 - Via the [CLI](https://docs.restate.dev/restate/cli):
     ```shell
-    restate dp register http://host.docker.internal:9080
+    restate dp register localhost:9080
     ```
-  When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
 - Via `curl`:
     ```shell
-    curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
+    curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
     ```
-  When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
+  
+When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
 
 This should give you the following output in case of the ticket reservation example:
 ```json

--- a/typescript/dynamic-workflow-executor/README.md
+++ b/typescript/dynamic-workflow-executor/README.md
@@ -44,13 +44,6 @@ In a real deployment, this would need to be a shared storage, like S3.
 
 ## Running the example
 
-### Deploy Restate Server
-
-Start the restate server via `npx`:
-```shell
-npx @restatedev/restate-server@latest
-```
-
 ### Deploy the services 
 
 Install the dependencies
@@ -83,14 +76,7 @@ Run workflow service:
 npm run workflow-service
 ```
 
-Register the services at the Restate Server, using the CLI:
-
-```shell
-npx @restatedev/restate dp reg localhost:9080
-npx @restatedev/restate dp reg localhost:9081
-npx @restatedev/restate dp reg localhost:9082
-npx @restatedev/restate dp reg localhost:9083
-```
+Now [launch the Restate Server](../../README.md#launching-the-restate-server) and [register the services](../../README.md#register-the-deployment-in-restate).
 
 ### OPTIONAL: Install and run stable diffusion server
 

--- a/typescript/dynamic-workflow-executor/README.md
+++ b/typescript/dynamic-workflow-executor/README.md
@@ -78,6 +78,8 @@ npm run workflow-service
 
 Now [launch the Restate Server](../../README.md#launching-the-restate-server) and [register the services](../../README.md#register-the-deployment-in-restate).
 
+Make sure you register all four services with the following ports: `9080`, `9081`, `9082` and `9083`.
+
 ### OPTIONAL: Install and run stable diffusion server
 
 **Note:** You can run this demo without Stable Diffusion. In that case, you cannot use workflow steps that call Stable Diffusion.

--- a/typescript/ecommerce-store/README.md
+++ b/typescript/ecommerce-store/README.md
@@ -79,7 +79,7 @@ npm run app
 
 The services are now running.
 
-See [how to launch the runtime](../../README.md#launching-the-runtime) and [how to discover services](../../README.md#connect-runtime-and-services) for details.
+See [how to launch the Restate Server](../../README.md#launching-the-restate-server) and [how to register services](../../README.md#register-the-deployment-in-restate) for details.
 
 Run the web app:
 

--- a/typescript/ecommerce-store/deployment/knative/README.md
+++ b/typescript/ecommerce-store/deployment/knative/README.md
@@ -53,7 +53,7 @@ You can visit the web app at http://localhost:3000
 kubectl port-forward -n shopping-cart svc/restate-runtime 8080:8080 9070:9070 9071:9071
 ```
 
-7. Execute the service discovery:
+7. Register the deployment in Restate:
 
 ```shell
 curl localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://services.shopping-cart.svc.cluster.local"}'

--- a/typescript/payment-api/README.md
+++ b/typescript/payment-api/README.md
@@ -53,7 +53,7 @@ npm run build
 npm run app
 ```
 
-Now [launch the runtime](../../README.md#launching-the-runtime) and [discover the services](../../README.md#connect-runtime-and-services).
+Now [launch the Restate Server](../../README.md#launching-the-restate-server) and [register the services](../../README.md#register-the-deployment-in-restate).
 
 Make a sample payment. The 'key' parameter is the idempotency token.
 

--- a/typescript/ticket-reservation/README.md
+++ b/typescript/ticket-reservation/README.md
@@ -92,9 +92,9 @@ npm run app
 
 The user session service, ticket service and checkout service are now up and running!
 
-### Launch Restate and discover services
+### Launch Restate and register services
 
-Now [launch the runtime](../../README.md#launching-the-runtime) and [discover the services](../../README.md#connect-runtime-and-services).
+Now [launch the Restate Server](../../README.md#launching-the-restate-server) and [register the services](../../README.md#register-the-deployment-in-restate).
 
 ### Call the service
 


### PR DESCRIPTION
- Unifies MacOS and Linus Docker commands
- CLI added as option for deployment registration
- Fixed the terminology around these two topics

Fixes #81 
Fixes https://github.com/restatedev/documentation/issues/285