### PR TITLE
Java template: pass greeting instead of name

### DIFF
--- a/templates/java-gradle/src/main/java/my/example/Greeter.java
+++ b/templates/java-gradle/src/main/java/my/example/Greeter.java
@@ -29,13 +29,13 @@ public class Greeter {
   private static final StateKey<Integer> COUNT = StateKey.of("count", CoreSerdes.JSON_INT);
 
   @Handler
-  public String greet(ObjectContext context, String name) {
+  public String greet(ObjectContext ctx, String greeting) {
     // Get the count and increment it
-    int count = context.get(COUNT).orElse(1);
-    context.set(COUNT, count + 1);
+    int count = ctx.get(COUNT).orElse(1);
+    ctx.set(COUNT, count + 1);
 
     // Send the response back
-    return "Hello " + name + " for the " + count + " time!";
+    return greeting + " " + ctx.key() + ", for the " + count + " time!";
   }
 
   public static void main(String[] args) {

--- a/templates/kotlin-gradle/src/main/kotlin/my/example/Greeter.kt
+++ b/templates/kotlin-gradle/src/main/kotlin/my/example/Greeter.kt
@@ -14,11 +14,11 @@ class Greeter {
   }
 
   @Handler
-  suspend fun greet(ctx: ObjectContext, name: String): String {
+  suspend fun greet(ctx: ObjectContext, greeting: String): String {
     val count = ctx.get(COUNT) ?: 1
     ctx.set(COUNT, count + 1)
 
-    return "Hello $name for the $count time!"
+    return "$greeting ${ctx.key()} for the $count time!"
   }
 }
 


### PR DESCRIPTION
Passes the greeting instead of the name as the request body.
The name is already the key of the virtual object.