### PR TITLE
Bump Node.js templates dependencies

### DIFF
--- a/templates/typescript-lambda-cdk/package.json
+++ b/templates/typescript-lambda-cdk/package.json
@@ -14,17 +14,17 @@
   },
   "devDependencies": {
     "@restatedev/restate-cdk": "^1.0.0",
-    "@types/node": "20.12.7",
-    "@typescript-eslint/eslint-plugin": "^7.7.1",
-    "aws-cdk": "^2.138.0",
-    "esbuild": "^0.20.2",
-    "prettier": "^3.2.5",
+    "@types/node": "20.14.2",
+    "@typescript-eslint/eslint-plugin": "^7.13.0",
+    "aws-cdk": "^2.145.0",
+    "esbuild": "^0.21.5",
+    "prettier": "^3.3.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   },
   "dependencies": {
     "@restatedev/restate-sdk": "^1.0.0",
-    "aws-cdk-lib": "^2.138.0",
+    "aws-cdk-lib": "^2.145.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"
   }

--- a/templates/typescript/package.json
+++ b/templates/typescript/package.json
@@ -16,9 +16,9 @@
     "@restatedev/restate-sdk": "^1.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.12.7",
-    "esbuild": "^0.18.12",
-    "ts-node-dev": "^1.1.1",
+    "@types/node": "^20.14.2",
+    "esbuild": "^0.21.5",
+    "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
Bump dependencies to fix npm reported vulnerable outdated versions warnings.