### PR TITLE
Improvements to the Java food-order Example

### DIFF
--- a/end-to-end-applications/java/food-ordering/app/restate-app/build.gradle.kts
+++ b/end-to-end-applications/java/food-ordering/app/restate-app/build.gradle.kts
@@ -40,7 +40,7 @@ application {
 }
 
 jib {
-    to.image = "restate-app:0.0.1"
+    to.image = "delivery-service:1.0.0"
     container.mainClass  = "dev.restate.sdk.examples.AppMain"
 }
 

--- a/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/AppMain.java
+++ b/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/AppMain.java
@@ -11,7 +11,6 @@
 
 package dev.restate.sdk.examples;
 
-import dev.restate.sdk.examples.external.DriverMobileAppSimulator;
 import dev.restate.sdk.http.vertx.RestateHttpEndpointBuilder;
 
 public class AppMain {
@@ -22,7 +21,6 @@ public class AppMain {
         .bind(new DeliveryManager())
         .bind(new DriverDeliveryMatcher())
         .bind(new DriverDigitalTwin())
-        .bind(new DriverMobileAppSimulator()) // external mobile app on driver's phone
-        .buildAndListen();
+        .buildAndListen(9080);
   }
 }

--- a/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/DriverDigitalTwin.java
+++ b/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/DriverDigitalTwin.java
@@ -134,18 +134,17 @@ public class DriverDigitalTwin {
 
   /** Gets called by the driver's mobile app when he has moved to a new location. */
   @Handler
-  public void handleDriverLocationUpdateEvent(ObjectContext ctx, Location location)
-      throws TerminalException {
+  public void handleDriverLocationUpdateEvent(ObjectContext ctx, Location location) {
     // Update the location of the driver
     ctx.set(DRIVER_LOCATION, location);
 
     // Update the location of the delivery, if there is one
-    ctx.get(ASSIGNED_DELIVERY)
-        .ifPresent(
-            delivery ->
-                DeliveryManagerClient.fromContext(ctx, delivery.getOrderId())
-                    .send()
-                    .handleDriverLocationUpdate(location));
+    Optional<AssignedDelivery> assignedDelivery = ctx.get(ASSIGNED_DELIVERY);
+    if (assignedDelivery.isPresent()) {
+      DeliveryManagerClient.fromContext(ctx, assignedDelivery.get().getOrderId())
+          .send()
+          .handleDriverLocationUpdate(location);
+    }
   }
 
   /**
@@ -154,8 +153,7 @@ public class DriverDigitalTwin {
    * got assigned to him.
    */
   @Handler
-  public Optional<AssignedDelivery> getAssignedDelivery(ObjectContext ctx)
-      throws TerminalException {
+  public Optional<AssignedDelivery> getAssignedDelivery(ObjectContext ctx) {
     return ctx.get(ASSIGNED_DELIVERY);
   }
 

--- a/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/OrderWorkflow.java
+++ b/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/OrderWorkflow.java
@@ -11,10 +11,10 @@
 
 package dev.restate.sdk.examples;
 
+import dev.restate.sdk.Context;
 import dev.restate.sdk.JsonSerdes;
-import dev.restate.sdk.ObjectContext;
 import dev.restate.sdk.annotation.Handler;
-import dev.restate.sdk.annotation.VirtualObject;
+import dev.restate.sdk.annotation.Service;
 import dev.restate.sdk.common.Serde;
 import dev.restate.sdk.common.TerminalException;
 import dev.restate.sdk.examples.clients.PaymentClient;
@@ -29,13 +29,13 @@ import java.time.Duration;
  * The event contains the order ID and the raw JSON order. The workflow handles the payment, asks
  * the restaurant to start the preparation, and triggers the delivery.
  */
-@VirtualObject
+@Service
 public class OrderWorkflow {
   private final RestaurantClient restaurant = RestaurantClient.get();
   private final PaymentClient paymentClnt = PaymentClient.get();
 
   @Handler
-  public void create(ObjectContext ctx, OrderRequest order) throws TerminalException {
+  public void create(Context ctx, OrderRequest order) throws TerminalException {
     String id = order.getOrderId();
 
     var orderStatusService = OrderStatusServiceClient.fromContext(ctx, id);

--- a/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/external/DriverMobileAppSimulator.java
+++ b/end-to-end-applications/java/food-ordering/app/restate-app/src/main/java/dev/restate/sdk/examples/external/DriverMobileAppSimulator.java
@@ -16,11 +16,12 @@ import dev.restate.sdk.annotation.Handler;
 import dev.restate.sdk.annotation.VirtualObject;
 import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.common.TerminalException;
-import dev.restate.sdk.examples.DriverDigitalTwinClient;
+import dev.restate.sdk.examples.*;
 import dev.restate.sdk.examples.clients.KafkaPublisher;
 import dev.restate.sdk.examples.types.AssignedDelivery;
 import dev.restate.sdk.examples.types.Location;
 import dev.restate.sdk.examples.utils.GeoUtils;
+import dev.restate.sdk.http.vertx.RestateHttpEndpointBuilder;
 import dev.restate.sdk.serde.jackson.JacksonSerdes;
 import java.time.Duration;
 import org.apache.logging.log4j.LogManager;
@@ -160,5 +161,11 @@ public class DriverMobileAppSimulator {
 
     // Call this method again after a short delay
     thisDriverSim.send(Duration.ofMillis(MOVE_INTERVAL)).move();
+  }
+
+  public static void main(String[] args) {
+    RestateHttpEndpointBuilder.builder()
+        .bind(new DriverMobileAppSimulator()) // external mobile app on driver's phone
+        .buildAndListen(9081);
   }
 }

--- a/end-to-end-applications/java/food-ordering/app/restaurant/build.gradle.kts
+++ b/end-to-end-applications/java/food-ordering/app/restaurant/build.gradle.kts
@@ -35,6 +35,6 @@ application {
 
 
 jib {
-    to.image = "restaurant-app:0.0.1"
+    to.image = "restaurant-app:1.0.0"
     container.mainClass  = "dev.restate.sdk.examples.RestaurantMain"
 }

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -40,20 +40,6 @@ services:
       kafka-topics --bootstrap-server broker:29092 --list
       "
 
-  rest-proxy:
-    image: confluentinc/cp-kafka-rest:7.5.0
-    ports:
-      - 8088:8088
-    hostname: rest-proxy
-    container_name: rest-proxy
-    environment:
-      KAFKA_REST_HOST_NAME: rest-proxy
-      KAFKA_REST_LISTENERS: "http://0.0.0.0:8088"
-      KAFKA_REST_BOOTSTRAP_SERVERS: "broker:29092"
-      KAFKA_REST_ACCESS_CONTROL_ALLOW_ORIGIN: "*"
-      KAFKA_REST_ACCESS_CONTROL_ALLOW_METHODS: "OPTIONS,GET,POST,PUT,DELETE"
-      KAFKA_REST_ACCESS_CONTROL_ALLOW_HEADERS: "origin,content-type,accept,authorization"
-
   jaeger:
     image: jaegertracing/all-in-one:1.47
     ports:
@@ -124,6 +110,7 @@ services:
       context: ./webui
     depends_on:
       - runtimesetup
-      - rest-proxy
     ports:
       - "3000:3000"
+    environment:
+      - REACT_APP_ENABLE_KAFKA=false

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -87,9 +87,7 @@ services:
   runtime:
     image: docker.io/restatedev/restate:1.0.1
     depends_on:
-      - restaurantpos
-      - broker
-      - rest-proxy
+      - init-kafka
       - jaeger
     ports:
       - "9070:9070"
@@ -107,6 +105,7 @@ services:
       - runtime
       - delivery_service
       - driver_app
+      - restaurantpos
     restart: "no"
     entrypoint: ["sh", "-c", "-x", "sleep 5 &&
     echo '-w \"\\n\"' >> ~/.curlrc &&
@@ -125,5 +124,6 @@ services:
       context: ./webui
     depends_on:
       - runtimesetup
+      - rest-proxy
     ports:
       - "3000:3000"

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=broker:29092
     entrypoint: ["java", "-cp", "@/app/jib-classpath-file", "dev.restate.sdk.examples.external.DriverMobileAppSimulator"]
 
+# To run the delivery services directly (in IDE, standalone), comment out this service
   delivery_service:
     container_name: delivery_service
     image: delivery-service:1.0.0
@@ -83,13 +84,15 @@ services:
       - ./restate-docker.toml:/restate.toml:Z,ro
     environment:
       - RESTATE_CONFIG=/restate.toml
+# remove those comments when running delivery services directly (in IDE, standalone), so the runtime can reach out to them
+#    extra_hosts:
+#      - "delivery_service:host-gateway"
 
   runtimesetup:
     build:
       context: ./tools
     depends_on:
       - runtime
-      - delivery_service
       - driver_app
       - restaurantpos
     restart: "no"

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -79,7 +79,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=broker:29092
 
   runtime:
-    image: docker.io/restatedev/restate
+    image: docker.io/restatedev/restate:1.0.0
     depends_on:
       - restaurantpos
       - broker
@@ -95,13 +95,13 @@ services:
       - RESTATE_CONFIG=/restate.toml
 
   runtimesetup:
-    image: alpine
+    build:
+      context: ./tools
     depends_on:
       - runtime
       - restate_app
     restart: "no"
     entrypoint: ["sh", "-c", "sleep 5 && 
-    apk add --no-cache bash jq curl &&
     curl -X POST 'runtime:9070/deployments' -H 'content-type: application/json' -d '{\"uri\": \"http://restate_app:9080\"}' &&
     sleep 3 && 
     curl -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/orders\", \"sink\":\"service://OrderWorkflow/create\" }' &&

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -64,22 +64,28 @@ services:
 
   restaurantpos:
     container_name: restaurantpos
-    image: restaurant-app:0.0.1
+    image: restaurant-app:1.0.0
     environment:
       - RESTATE_RUNTIME_ENDPOINT=http://runtime:8080
     ports:
       - "5050:5050"
     entrypoint: ["java", "-cp", "@/app/jib-classpath-file", "dev.restate.sdk.examples.RestaurantMain"]
 
-  restate_app:
-    container_name: restate_app
-    image: restate-app:0.0.1
+  driver_app:
+    container_name: driver_app
+    image: delivery-service:1.0.0
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=broker:29092
+    entrypoint: ["java", "-cp", "@/app/jib-classpath-file", "dev.restate.sdk.examples.external.DriverMobileAppSimulator"]
+
+  delivery_service:
+    container_name: delivery_service
+    image: delivery-service:1.0.0
     environment:
       - RESTAURANT_ENDPOINT=http://restaurantpos:5050
-      - KAFKA_BOOTSTRAP_SERVERS=broker:29092
 
   runtime:
-    image: docker.io/restatedev/restate:1.0.0
+    image: docker.io/restatedev/restate:1.0.1
     depends_on:
       - restaurantpos
       - broker
@@ -99,11 +105,13 @@ services:
       context: ./tools
     depends_on:
       - runtime
-      - restate_app
+      - delivery_service
+      - driver_app
     restart: "no"
     entrypoint: ["sh", "-c", "-x", "sleep 5 &&
     echo '-w \"\\n\"' >> ~/.curlrc &&
-    curl -i -s --fail -X POST 'runtime:9070/deployments' -H 'content-type: application/json' -d '{\"uri\": \"http://restate_app:9080\"}' &&
+    curl -i -s --fail -X POST 'runtime:9070/deployments' -H 'content-type: application/json' -d '{\"uri\": \"http://delivery_service:9080\"}' &&
+    curl -i -s --fail -X POST 'runtime:9070/deployments' -H 'content-type: application/json' -d '{\"uri\": \"http://driver_app:9081\"}' &&
     sleep 3 && 
     curl -i -s --fail -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/orders\", \"sink\":\"service://OrderWorkflow/create\" }' &&
     curl -i -s --fail -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/driver-updates\", \"sink\":\"service://DriverDigitalTwin/handleDriverLocationUpdateEvent\" }' &&

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - RESTAURANT_ENDPOINT=http://restaurantpos:5050
 
   runtime:
-    image: docker.io/restatedev/restate:1.0.1
+    image: docker.io/restatedev/restate:1.0.2
     depends_on:
       - init-kafka
       - jaeger

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -101,14 +101,15 @@ services:
       - runtime
       - restate_app
     restart: "no"
-    entrypoint: ["sh", "-c", "sleep 5 && 
-    curl -X POST 'runtime:9070/deployments' -H 'content-type: application/json' -d '{\"uri\": \"http://restate_app:9080\"}' &&
+    entrypoint: ["sh", "-c", "-x", "sleep 5 &&
+    echo '-w \"\\n\"' >> ~/.curlrc &&
+    curl -i -s --fail -X POST 'runtime:9070/deployments' -H 'content-type: application/json' -d '{\"uri\": \"http://restate_app:9080\"}' &&
     sleep 3 && 
-    curl -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/orders\", \"sink\":\"service://OrderWorkflow/create\" }' &&
-    curl -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/driver-updates\", \"sink\":\"service://DriverDigitalTwin/handleDriverLocationUpdateEvent\" }' &&
+    curl -i -s --fail -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/orders\", \"sink\":\"service://OrderWorkflow/create\" }' &&
+    curl -i -s --fail -X POST 'runtime:9070/subscriptions' -H 'content-type: application/json' -d '{ \"source\":\"kafka://my-cluster/driver-updates\", \"sink\":\"service://DriverDigitalTwin/handleDriverLocationUpdateEvent\" }' &&
     sleep 3 && 
-    curl -X POST 'runtime:8080/DriverMobileAppSimulator/driver-A/startDriver' && 
-    curl -X POST 'runtime:8080/DriverMobileAppSimulator/driver-B/startDriver' && 
+    curl -i -s --fail -X POST 'runtime:8080/DriverMobileAppSimulator/driver-A/startDriver' &&
+    curl -i -s --fail -X POST 'runtime:8080/DriverMobileAppSimulator/driver-B/startDriver' &&
     exit 1"]
 
   foodorderingwebui:

--- a/end-to-end-applications/java/food-ordering/docker-compose.yaml
+++ b/end-to-end-applications/java/food-ordering/docker-compose.yaml
@@ -3,13 +3,10 @@ services:
   broker:
     image: confluentinc/cp-kafka:7.5.0
     container_name: broker
-    ports:
-      - "9092:9092"
-      - "9101:9101"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://broker:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
@@ -44,7 +41,6 @@ services:
     image: jaegertracing/all-in-one:1.47
     ports:
       - "16686:16686"
-      - "4317:4317"
     environment:
       - COLLECTOR_OTLP_ENABLED=true
 
@@ -54,7 +50,7 @@ services:
     environment:
       - RESTATE_RUNTIME_ENDPOINT=http://runtime:8080
     ports:
-      - "5050:5050"
+      - "5050:5050"  # exposed so that can be called when delivery services run outside docker compose
     entrypoint: ["java", "-cp", "@/app/jib-classpath-file", "dev.restate.sdk.examples.RestaurantMain"]
 
   driver_app:

--- a/end-to-end-applications/java/food-ordering/restate-docker.toml
+++ b/end-to-end-applications/java/food-ordering/restate-docker.toml
@@ -3,3 +3,14 @@ tracing-endpoint = "http://jaeger:4317"
 [[ingress.kafka-clusters]]
 name = "my-cluster"
 brokers = ["PLAINTEXT://broker:29092"]
+
+[http-keep-alive-options]
+interval = "40s"
+timeout = "2000000s"
+
+[worker.invoker]
+inactivity-timeout = "100m"
+abort-timeout = "100m"
+
+[worker.invoker.retry-policy]
+max-interval = "2s"

--- a/end-to-end-applications/java/food-ordering/tools/Dockerfile
+++ b/end-to-end-applications/java/food-ordering/tools/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+
+RUN apk add --no-cache bash jq curl
+

--- a/end-to-end-applications/java/food-ordering/webui/src/services/sendToRestate.ts
+++ b/end-to-end-applications/java/food-ordering/webui/src/services/sendToRestate.ts
@@ -4,30 +4,16 @@ const RESTATE_HOST =
   process.env.REACT_APP_RESTATE_HOST || 'http://localhost:8080';
 const KAFKA_REST_PROXY_HOST = 'http://localhost:8088';
 
-const challenge = (): { challenge: string; challengeTime: string } => {
-  const challengeTime = new Date().getTime();
-  const challenge = challengeTime ^ 7925119523126;
-  return {
-    challenge: challenge.toString(),
-    challengeTime: challengeTime.toString(),
-  };
-};
-
-const challengeHeaders = () => {
-  const c = challenge();
-
-  return { 'X-Challenge': c.challenge, 'X-Challenge-Time': c.challengeTime };
-};
 
 export async function createOrder(orderId: string, order: any) {
   return await (
     await axios.post(
-      `${RESTATE_HOST}/OrderWorkflow/${orderId}/create`,
+      `${RESTATE_HOST}/OrderWorkflow/create/send`,
       order,
       {
         headers: {
           'content-type': 'application/json',
-          ...challengeHeaders(),
+          'idempotency-key': orderId
         },
       }
     )
@@ -36,9 +22,7 @@ export async function createOrder(orderId: string, order: any) {
 
 export async function getStatus(orderId: string) {
   return await (
-    await axios.get(`${RESTATE_HOST}/OrderStatusService/${orderId}/get`, {
-      headers: challengeHeaders(),
-    })
+    await axios.get(`${RESTATE_HOST}/OrderStatusService/${orderId}/get`, {})
   ).data;
 }
 


### PR DESCRIPTION
Various changes, most importantly
 - Making it very simple to run the services (except driver mobile app simulator) outside docker (e.g., IDE). This is very useful for interactive demos with failures, debuggers, etc.
 - setup works offline (after containers are built) - also helpful for conference demos where internet access may be flaky
 - removing kafka during order submit, using it only for the driver app status updates. this allows us to remove the rest proxy and simplify code, like making the order workflow a service (not an object), ensuring idempotency simply via adding idempotency keys in the web UI, etc.