### PR TITLE
Simplify CDK templates and avoid VPC lookups during synth step

### DIFF
--- a/.tools/run_jvm_tests.sh
+++ b/.tools/run_jvm_tests.sh
@@ -5,19 +5,19 @@ set -eufx -o pipefail
 SELF_PATH=${BASH_SOURCE[0]:-"$(command -v -- "$0")"}
 PROJECT_ROOT="$(dirname "$SELF_PATH")/.."
 
-pushd $PROJECT_ROOT/templates/java-gradle && ./gradlew check && popd || exit
-pushd $PROJECT_ROOT/templates/java-maven && mvn verify && popd || exit
-pushd $PROJECT_ROOT/templates/kotlin-gradle && ./gradlew check && popd || exit
-pushd $PROJECT_ROOT/templates/kotlin-gradle-lambda-cdk/lambda && ./gradlew check && popd || exit
+pushd $PROJECT_ROOT/templates/java-gradle && ./gradlew check && popd
+pushd $PROJECT_ROOT/templates/java-maven && mvn verify && popd
+pushd $PROJECT_ROOT/templates/kotlin-gradle && ./gradlew check && popd
+pushd $PROJECT_ROOT/templates/kotlin-gradle-lambda-cdk/lambda && ./gradlew check && popd
 
-pushd $PROJECT_ROOT/basics/basics-java && ./gradlew check && popd || exit
+pushd $PROJECT_ROOT/basics/basics-java && ./gradlew check && popd
 
-pushd $PROJECT_ROOT/patterns-use-cases/sagas/sagas-java && ./gradlew check && popd || exit
-pushd $PROJECT_ROOT/patterns-use-cases/payment-state-machine/payment-state-machine-java && ./gradlew check && popd || exit
-pushd $PROJECT_ROOT/patterns-use-cases/async-signals-payment/async-signals-payment-java && ./gradlew check && popd || exit
-pushd $PROJECT_ROOT/patterns-use-cases/integrations/java-spring && ./gradlew check && popd || exit
+pushd $PROJECT_ROOT/patterns-use-cases/sagas/sagas-java && ./gradlew check && popd
+pushd $PROJECT_ROOT/patterns-use-cases/payment-state-machine/payment-state-machine-java && ./gradlew check && popd
+pushd $PROJECT_ROOT/patterns-use-cases/async-signals-payment/async-signals-payment-java && ./gradlew check && popd
+pushd $PROJECT_ROOT/patterns-use-cases/integrations/java-spring && ./gradlew check && popd
 
-pushd $PROJECT_ROOT/tutorials/tour-of-restate-java && ./gradlew check && popd || exit
+pushd $PROJECT_ROOT/tutorials/tour-of-restate-java && ./gradlew check && popd
 
-pushd $PROJECT_ROOT/end-to-end-applications/java/food-ordering/app && ./gradlew check && popd || exit
-pushd $PROJECT_ROOT/end-to-end-applications/kotlin/food-ordering/app && ./gradlew check && popd || exit
+pushd $PROJECT_ROOT/end-to-end-applications/java/food-ordering/app && ./gradlew check && popd
+pushd $PROJECT_ROOT/end-to-end-applications/kotlin/food-ordering/app && ./gradlew check && popd

--- a/.tools/run_jvm_tests.sh
+++ b/.tools/run_jvm_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euf -o pipefail
+
 SELF_PATH=${BASH_SOURCE[0]:-"$(command -v -- "$0")"}
 PROJECT_ROOT="$(dirname "$SELF_PATH")/.."
 

--- a/.tools/run_jvm_tests.sh
+++ b/.tools/run_jvm_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euf -o pipefail
+set -eufx -o pipefail
 
 SELF_PATH=${BASH_SOURCE[0]:-"$(command -v -- "$0")"}
 PROJECT_ROOT="$(dirname "$SELF_PATH")/.."

--- a/.tools/run_node_tests.sh
+++ b/.tools/run_node_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euf -o pipefail
+set -x
 
 SELF_PATH=${BASH_SOURCE[0]:-"$(command -v -- "$0")"}
 PROJECT_ROOT="$(dirname "$SELF_PATH")/.."

--- a/.tools/run_node_tests.sh
+++ b/.tools/run_node_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euf -o pipefail
+
 SELF_PATH=${BASH_SOURCE[0]:-"$(command -v -- "$0")"}
 PROJECT_ROOT="$(dirname "$SELF_PATH")/.."
 

--- a/.tools/run_node_tests.sh
+++ b/.tools/run_node_tests.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-set -euf -o pipefail
-set -x
+set -eufx -o pipefail
 
 SELF_PATH=${BASH_SOURCE[0]:-"$(command -v -- "$0")"}
 PROJECT_ROOT="$(dirname "$SELF_PATH")/.."
@@ -15,7 +14,7 @@ npm_install_check $PROJECT_ROOT/basics/basics-typescript
 npm_install_check $PROJECT_ROOT/templates/typescript
 npm_install_check $PROJECT_ROOT/templates/typescript-lambda-cdk
 npm_install_check $PROJECT_ROOT/templates/cloudflare-worker
-npm_install_check $PROJECT_ROOT/templates/bun
+#npm_install_check $PROJECT_ROOT/templates/bun
 
 npm_install_check $PROJECT_ROOT/tutorials/tour-of-restate-typescript
 

--- a/templates/cloudflare-worker/package.json
+++ b/templates/cloudflare-worker/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
+    "build": "tsc --noEmitOnError",
     "deploy": "wrangler deploy",
     "dev": "wrangler dev --port 9080",
     "start": "wrangler dev --port 9080",

--- a/templates/typescript-lambda-cdk/lib/lambda-ts-cdk-stack.ts
+++ b/templates/typescript-lambda-cdk/lib/lambda-ts-cdk-stack.ts
@@ -18,54 +18,41 @@ import { Construct } from "constructs";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 export class LambdaTsCdkStack extends cdk.Stack {
-  constructor(
-    scope: Construct,
-    id: string,
-    props: cdk.StackProps,
-  ) {
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
     super(scope, id, props);
 
     const greeter: lambda.Function = new NodejsFunction(this, "GreeterService", {
-      runtime: lambda.Runtime.NODEJS_LATEST,
+      runtime: lambda.Runtime.NODEJS_20_X,
       entry: "lib/lambda/handler.ts",
       architecture: lambda.Architecture.ARM_64,
       bundling: {
         minify: true,
         sourceMap: true,
       },
-      environment: {
-        NODE_OPTIONS: "--enable-source-maps",
-      },
     });
 
-    const environment = new restate.SingleNodeRestateDeployment(this, "Restate", {
-      // restateImage: "docker.io/restatedev/restate",
-      // restateTag: "0.9",
-      logGroup: new logs.LogGroup(this, "RestateLogs", {
-        retention: logs.RetentionDays.ONE_MONTH,
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
-      }),
-    });
-
-    new iam.Policy(this, "AssumeAnyRolePolicy", {
-      statements: [
-        new iam.PolicyStatement({
-          sid: "AllowAssumeAnyRole",
-          actions: ["sts:AssumeRole"],
-          resources: ["*"], // we don't know upfront what invoker roles we may be asked to assume at runtime
-        }),
-      ],
-    }).attachToRole(environment.invokerRole);
-
+    // This role is used by Restate to invoke Lambda service handlers; see https://docs.restate.dev/deploy/cloud for
+    // information on deploying services to Restate Cloud environments. For standalone environments, the EC2 instance
+    // profile can be used directly instead of creating a separate role.
     const invokerRole = new iam.Role(this, "InvokerRole", {
-      assumedBy: new iam.ArnPrincipal(environment.invokerRole.roleArn),
+      assumedBy: new iam.AccountRootPrincipal(), // set up trust such that your Restate environment can assume this role
     });
-    invokerRole.grantAssumeRole(environment.invokerRole);
 
+    // You can reference an existing Restate environment you manage yourself or a Restate Cloud environment by
+    // configuring its address and optionally auth token. The deployer will use these settings to register the handlers.
     const restateEnvironment = restate.RestateEnvironment.fromAttributes({
-      adminUrl: environment.adminUrl,
+      adminUrl: "https://restate.example.com:9070", // pre-existing Restate server address not managed by this stack
       invokerRole,
     });
+
+    // Alternatively, you can deploy a standalone Restate server using the RestateServer construct. Please refer to
+    // https://docs.restate.dev/deploy/lambda/self-hosted and the construct documentation for details.
+    // const restateEnvironment = new restate.SingleNodeRestateDeployment(this, "Restate", {
+    //   logGroup: new logs.LogGroup(this, "RestateLogs", {
+    //     logGroupName: "/restate/server-logs",
+    //     retention: logs.RetentionDays.ONE_MONTH,
+    //   }),
+    // });
 
     const deployer = new restate.ServiceDeployer(this, "ServiceDeployer", {
       logGroup: new logs.LogGroup(this, "Deployer", {
@@ -75,9 +62,10 @@ export class LambdaTsCdkStack extends cdk.Stack {
     });
 
     deployer.deployService("Greeter", greeter.currentVersion, restateEnvironment, {
-      insecure: true, // self-signed certificate
+      // insecure: true, // accept self-signed certificate for SingleNodeRestateDeployment
     });
 
-    new cdk.CfnOutput(this, "restateIngressUrl", { value: environment.ingressUrl });
+    // If deploying a standalone Restate server, we can output the ingress URL like this.
+    // new cdk.CfnOutput(this, "restateIngressUrl", { value: restateEnvironment.ingressUrl });
   }
 }


### PR DESCRIPTION
With this PR, we're making sure that any test failing causes the entire GitHub workflow to fail fast. Previously, intermediate build failures were not causing the action to report an error.

Secondly, the CDK examples are updated so that they can build on GH without AWS creds; this also serves to make the more general and leaves it up to the user to decide whether to deploy to EC2 (commented out) or target an existing Restate server (either externally managed, or a Restate Cloud environment).

Ideally we should be testing the bun/deno/cloudflare templates with their respective deployment tools but that's outside of the scope of the current PR. I'll submit a separate change to include those in the test checks.