### PR TITLE
docs: minor doc changes

### DIFF
--- a/end-to-end-applications/kotlin/food-ordering/README.md
+++ b/end-to-end-applications/kotlin/food-ordering/README.md
@@ -18,7 +18,7 @@ It also interacts with the delivery services to get the order delivered to the c
 - Via git clone:
     ```shell
     git clone git@github.com:restatedev/examples.git
-    cd examples/kotlin/food-ordering
+    cd examples/end-to-end-applications/kotlin/food-ordering
     ```
 
 - Via `wget`:
@@ -32,7 +32,7 @@ Build the docker containers:
 
 ```shell
 cd app
-./gradlew clean build jibDockerBuild
+./gradlew build jibDockerBuild
 ```
 
 Launch the Docker compose setup:


### PR DESCRIPTION
The path for the examples was wrong.

In addition it's recommended not to run clean on gradle each time

https://tomgregory.com/gradle/gradle-best-practices/#2-stop-cleaning-your-project