### PR TITLE
Add example for database access patterns

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -26,6 +26,7 @@ Common tasks and patterns implemented with Restate:
 | Async tasks      | [Payments: async signals processing](patterns-use-cases/async-tasks-payment-signals) | Advanced    | Handling async payment callbacks for slow payments, with Stripe.                                            |
 | Event processing | [Transactional handlers](patterns-use-cases/event-processing-transactional-handlers) | Basic       | Processing events (from Kafka) to update various downstream systems in a transactional way.                 |
 | Event processing | [Enriching streams](patterns-use-cases/event-processing-enrichment)                  | Basic       | Stateful functions/actors connected to Kafka and callable over RPC.                                         |
+| Patterns         | [Database Access Patterns](patterns-use-cases/database-access)                       | Intermediate | Patterns for accessing databases with and without idempotency or transactional integration.                |
 | Patterns         | [Durable Promises](patterns-use-cases/pattern-durable-promises)                      | Advanced    | Implementation of Promises/Futures that are durable across processes and failures.                          |
 | Patterns         | [Priority Queue](patterns-use-cases/pattern-priority-queue)                          | Advanced    | Example of implementing a priority queue to manage task execution order.                                    |
 

--- a/typescript/patterns-use-cases/database-access/README.md
+++ b/typescript/patterns-use-cases/database-access/README.md
@@ -1,0 +1,77 @@
+# Updating and Accessing Databases
+
+This set of examples shows various patterns to access databases from Restate handlers.
+
+The basic premise is:
+
+1. You don't need to do anything special, you can just interact with
+   your database the same way as from other microservices or workflow activities.
+
+2. But you can use Restate's state, journal, and concurrency mechanisms
+   as helpers to improve common access problems, solve race conditions,
+   or avoid inconsistencies in the presence of retries, concurrent requests,
+   or zombie processes.
+
+The code in [main.ts](./src/main.ts) walks gradually through those patterns and explains
+them with inline comments.
+
+### Running the Example
+
+_This is purely opional, the example code and comments document the behavior well._
+_Running the example can be interesting, though, if you want to play with specific failure_
+_scenarios, like pausing/killing processes at specific points and observe the behavior._
+
+**Sample Postgres Instance**
+
+To run this example, you need a PostgreSQL database that the Restate handlers will
+access/modify. Simply start one using this Docker command (from the example directory,
+i.e., the directory containing this README file!).
+
+```shell
+docker run -it --rm \
+  --name restate_example_db \
+  -e POSTGRES_USER=restatedb \
+  -e POSTGRES_PASSWORD=restatedb \
+  -e POSTGRES_DB=exampledb \
+  -p 5432:5432 \
+  -v "$(pwd)/database:/docker-entrypoint-initdb.d" \
+  postgres:15.0-alpine
+```
+
+In a separate shell, you can check the contents of the database via those queries
+(requires `psql` to be installed):
+```shell
+psql postgresql://restatedb:restatedb@localhost:5432/exampledb -c 'SELECT * FROM users;'
+psql postgresql://restatedb:restatedb@localhost:5432/exampledb -c 'SELECT * FROM user_idempotency;'
+```
+
+**Running Example Code**
+
+Start Restate Server, start the app service (`npm run example`) and register the service (running on port 9080).
+
+See the [root README](/restatedev/examples/tree/main?tab=readme-ov-file#running-the-examples) for details.
+
+**Example Commands**
+
+The below commands trigger the individual example handlers in the different services.
+
+As with all Restate invocations, you can add idempotency keys to the invoking HTTP calls to make sure
+retries from HTTP clients are de-duplicated by Restate.
+Add an idempotency-key header by appending `-H 'idempotency-key: <mykey>'` to any command, for example: `curl -i localhost:8080/keyed/A/updateConditional --json '12' -H 'idempotency-key: abcdef'`.
+As with all Restate handlers, if you invoke them from within another Restate handler via the Context, invocations are automatically made idempotent.
+
+Simple DB operations:
+* Simple read: `curl -i localhost:8080/simple/read --json '"A"'`
+* Durable read: `curl -i localhost:8080/simple/durableRead --json '"B"'`
+* Insert: `curl -i localhost:8080/simple/insert  --json '{ "userId": "C", "name": "Emm", "address": "55, Rue du Faubourg Saint-Honoré, 75008 Paris, France", "credits": 1337 }'`
+* Update: `curl -i localhost:8080/simple/update  --json '{ "userId": "A", "newName": "Donald" }'`
+
+Keyed DB Operations:
+* Update simple: `curl -i localhost:8080/keyed/B/update --json '12'`
+* Update exactly-once: `curl -i localhost:8080/keyed/B/updateConditional --json '12'`
+
+
+Idempotency update:
+* Updating exactly-once: `curl -i localhost:8080/idempotency/update --json '{ "userId": "A", "addCredits": 100 }'`
+
+

--- a/typescript/patterns-use-cases/database-access/database/init.sql
+++ b/typescript/patterns-use-cases/database-access/database/init.sql
@@ -1,0 +1,18 @@
+create table if not exists users (
+       userid varchar(255) not null,
+       name varchar(255) not null,
+       address varchar(255) not null,
+       credits numeric not null,
+       version numeric not null,
+       primary key (userid)
+);
+
+create table if not exists user_idempotency (
+       id varchar(255) not null,
+       primary key (id)
+);
+
+insert into users(userid, name, address, credits, version)
+values ('A', 'Don', '1600 Pennsylvania Avenue NW, Washington, DC 20500, USA', 1000, 0),
+       ('B', 'Keir', '10 Downing St, London SW1A 2AB, UK', 1000, 0);
+

--- a/typescript/patterns-use-cases/database-access/package.json
+++ b/typescript/patterns-use-cases/database-access/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@restatedev/examples-database",
+  "version": "1.0.0",
+  "description": "Example of accessing databases from Restate",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc --noEmitOnError",
+    "example": "ts-node --transpile-only ./src/main.ts"
+  },
+  "dependencies": {
+    "@restatedev/restate-sdk": "^1.4.0",
+    "pg": "^8.10.0",
+    "sequelize": "^6.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.0.2"
+  }
+}

--- a/typescript/patterns-use-cases/database-access/src/main.ts
+++ b/typescript/patterns-use-cases/database-access/src/main.ts
@@ -1,0 +1,349 @@
+import * as restate from "@restatedev/restate-sdk";
+import { Sequelize, Transaction } from "sequelize";
+
+// ----------------------------------------------------------------------------
+//
+//  This example shows various patterns to access databases from Restate
+//  handlers.
+//
+//  The basics are:
+//
+//  (1) You don't need to do anything special, you can just interact with
+//      your database the same way as from other microservices or
+//      workflow activities.
+//
+//  (2) But you can use Restate's state, journal, and concurrency mechanisms
+//      as helpers to improve common access problems, solve race conditions,
+//      or avoid inconsistencies in the presence of retries, concurrent requests,
+//      or zombie processes.
+//
+// The below example illustrate this step by step.
+//
+// ----------------------------------------------------------------------------
+
+type Row = {
+    userId: string,        // the primary key
+    name: string,
+    address: string,
+    credits: number,
+    version?: number,   // the row version (used by some access methods)
+}
+
+const db = new Sequelize(
+    "postgres://restatedb:restatedb@localhost:5432/exampledb",
+    { logging: false }
+);
+
+// ----------------------------------------------------------------------------
+
+/**
+ * This service implements the database accesses similar to the way you
+ * might access the database from other microservices.
+ * It doesn't use any Restate features to help making the DB access consistent.
+ */
+const simpledbAccess = restate.service({
+    name: "simple",
+    handlers: {
+
+        /**
+         * Simple read from a database row.
+         * This is the same as it would be from any non-Restate service.
+         */
+        read: async (_ctx: restate.Context, userid: string) => {
+            const [results, _meta] = await db.query(
+                `SELECT *
+                   FROM users
+                  WHERE userid = '${userid}'`
+            );
+            return results.length > 0 ? results[0] : "(row not found)";
+        },
+
+        /**
+         * This performs a read in a Restate durable action, persisting the result.
+         * The read access is the same as in a non-Restate service, but the result
+         * is persisted in the execution journal.
+         * 
+         * This is useful for example, if you have decisions/branches based on
+         * the result and want to ensure consistent and deterministic behavior
+         * on retries (where the value in the database might have changed
+         * in-between retries).
+         */
+        durableRead: async (ctx: restate.Context, userid: string) => {
+            const credits = await ctx.run("read credits", async () => {
+                const [results, _metadata] = await db.query(
+                    `SELECT credits
+                       FROM users
+                      WHERE userid = '${userid}'`
+                );
+                return (results[0] as any)?.credits;
+            });
+
+            if (credits === 0) {
+                // Execute some conditional logic, e.g., alerting, sending reminder.
+                // Automatic retries (on failure) will follow this branch again (using
+                // Restate's journalled value for 'credits') so code in this branch will
+                // reliably run to conclusion
+                console.log("Found an account without balance, doing something about it...");
+            }
+
+            return credits;
+        },
+
+        /**
+         * Inserts a row into the database. No Restate-specific handling, this
+         * simply uses the database's primary key uniqueness to avoid duplicate
+         * entries.
+         */
+        insert: async (_ctx: restate.Context, row: Row) => {
+            const { userId, name, address, credits } = row;
+
+            const [_, numInserted] = await db.query(
+                `INSERT INTO users (userid, name, address, credits, version)
+                      VALUES ('${userId}', '${name}', '${address}', ${credits}, 0)
+                 ON CONFLICT (userid) DO NOTHING`
+            );
+            return numInserted === 1;
+        },
+
+        /**
+         * Updates a row in a database. This handler makes no specific effort to
+         * add idempotency, so it purely relies on database / application semantics.
+         * It is vulnerable to concurrent updates overwriting each other, but can make
+         * sense if this is fine for a specific type of (rare) update.
+         * 
+         * For an example that use Restate to add consistency, see the examples
+         * further below.
+         */
+        update: async (_ctx: restate.ObjectContext, update: { userId: string, newName: string }) => {
+            const { userId, newName } = update;
+            
+            // Update row - we execute this statement directly, because it is the only
+            // step in this handler. If the handler contains multiple steps, wrap this in
+            // a `ctx.run( () => { ... } )` block to ensure it does not get re-executed once
+            // during retries of successive steps
+        
+            const [_, meta] = await db.query(
+                `UPDATE users
+                    SET name = '${newName}'
+                  WHERE userID = '${userId}'`
+            );
+            return (meta as any).rowCount === 1;
+        }
+    }
+})
+
+// ----------------------------------------------------------------------------
+
+/*
+ * When updating single rows by primary key (on a database or a key/value store),
+ * you can use Virtual Objects to serialize access per key. This happens automatically
+ * if you access the database from a Virtual Object and use the same key for object and
+ * primary key in the database.
+ *
+ * Most databases internally serialize updates on the same row anyways (either through locks,
+ * or by detecting conflicts during when attempting to commit transactions and rolling back), so
+ * making the access sequential from the application can help to avoid lock congestion and
+ * avoid pathological degradation of optimistic concurrency control around contended keys.
+ *
+ * Furthermore, this update pattern makes it possible to use conditional updates with versions
+ * that don't get duplicated on retries, resulting in proper exactly-once semantics.
+ */
+const keyedDbAccess = restate.object({
+    name: "keyed",
+    handlers: {
+
+        /**
+         * Updates the credits for a row in a database.
+         * This variant makes no effort to ensure the update does not get duplicated.
+         * 
+         * In practice, this will can reasonably safe, because there is a very small window
+         * time where the query gets re-executed after success, whihc is when the query succeeded,
+         * but Restate did not see the completion of the handler.
+         * 
+         * Note that this is especially rare, since the single-writer-per-key semantics of the
+         * Virtual Object ensure that no contention on rows can happen in the database.
+         */
+        update: async (ctx: restate.ObjectContext, credits: number ) => {
+            const userid = ctx.key;
+
+            await db.query(
+                `UPDATE users
+                    SET credits = credits + ${credits}
+                  WHERE userid = '${userid}'`
+            );
+        },
+
+        /**
+         * Updates the 'credits' field and uses the 'version' number to make the update
+         * idempotent.
+         * 
+         * The approach is to separate reads (current credits, version) and
+         * updates into separate queries. The reads are kept in the execution journal, and
+         * the updates are conditional on the fact that the version did not change in between.
+         * This is sometimes referred to as a _semantic lock pattern_.
+         * 
+         * Because the reads go through a `ctx.run` step (strong consensus inside Restate),
+         * it is guaranteed that the same invocation will always work off of the same version.
+         * Regardless of partial failures/retries/zombies/network partitions, the code will
+         * always observe a single version.  
+         * 
+         * If all updates to the row go through this handler (or other handlers in this
+         * Virtual Object that use the versioning scheme) then no duplicates are possible.
+         */
+        updateConditional: async (ctx: restate.ObjectContext, addCredits: number) => {
+            const userid = ctx.key;
+
+            // first read the current credits and the version.
+            // Because the reads go through a `ctx.run` step (strong consensus), the
+            // a single invocation and all if its retries can never see different values
+            // for version and credits.  
+            const [ credits, version ] = await ctx.run("read credits, version", async () => {
+
+                const [results, _] = await db.query(
+                    `SELECT credits, version
+                       FROM users
+                      WHERE userid = '${userid}'`
+                );
+
+                if (results.length !== 1) {
+                    throw new restate.TerminalError(`No single row with userid = '${userid}'`);
+                }
+                const row = results[0] as any;
+                return [ Number(row.credits), Number(row.version)];
+            });
+
+            // Make the update conditional on the fact that the version is still the same (see
+            // 'AND version = ...'). If the version is no longer the same, it means that a
+            // previous execution attempt updated this and crashed before completing the handler).
+            // It cannot be completed by a concurrent query, because all operations on the userid
+            // are serialized through the Virtual Object.
+            const [_, meta] = await db.query(
+                `UPDATE users
+                    SET credits = ${credits + addCredits},
+                        version = ${version + 1}
+                  WHERE userid = '${userid}'
+                    AND version = ${version}`
+            );
+
+            if ((meta as any).rowCount !== 1) {
+                console.debug("Update was not applied - version no longer matches.");
+            }
+        },
+
+        /**
+         * Reads a row from the database.
+         * 
+         * This one is markes as a SHARED handler, which means it doesn't queue
+         * with the other invocations for this key. That way reads execute immediately
+         * and concurrently, while writes execute sequentially.
+         */
+        read: restate.handlers.object.shared(
+            async (ctx: restate.ObjectSharedContext) => {
+                const userid = ctx.key;
+
+                const [results, _meta] = await db.query(
+                    `SELECT *
+                       FROM users
+                      WHERE userid = '${userid}'`
+                );
+                return (results[0]) ?? "(row not found)";
+            }
+        )
+    }
+})
+
+// ----------------------------------------------------------------------------
+
+/**
+ * This service uses a second table in the database to remember idempotency tokens
+ * for each operation. The idempotency tokens are inserted into the database in the
+ * same transaction as the main operation.
+ * 
+ * The code uses Restate's features to deterministically generate the tokens and
+ * to expire them after a day.
+ */
+const idempotencyKeyDbAccess = restate.service({
+    name: "idempotency",
+    handlers: {
+
+        /**
+         * Adds credits to a single user entry. This operation is _idempotent_ within a
+         * time window of a day.
+         * 
+         * This handler uses a second table in the database to remember idempotency tokens
+         * for each update. The idempotency tokens are inserted into the database in the
+         * same transaction as the update.
+         * 
+         * The code uses Restate's features to deterministically generate the tokens and
+         * to expire them after a day. 
+         */
+        update: async (ctx: restate.Context, update: { userId: string, addCredits: number }) => {
+
+            // create a persistent idempotency key. we use Restate's random number generator,
+            // because that is the most efficient way to generate a durable deterministic ID.
+            const idempotencyKey = ctx.rand.uuidv4();
+
+            // expire the idempotency key from the database after one day = 86,400,000ms
+            // by scheduling a call to the handler that deletes the key
+            ctx.serviceSendClient(idempotencyKeyDbAccess, { delay: 86_400_000 })
+               .expireIdempotencyKey(idempotencyKey)
+
+            // checking the existence of the idempotency key and making the update happens
+            // in one database transaction
+            const tx = await db.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE });
+            try {
+                // first test whether the idempotency token exists by checking whether
+                // we can insert one into the table (primary key constraint prevents
+                // duplicates)
+                const [_tokenRows, numInserted] = await db.query(
+                    `INSERT INTO user_idempotency (id)
+                        VALUES ('${idempotencyKey}')
+                    ON CONFLICT (id) DO NOTHING`,
+                    { transaction: tx }
+                );
+        
+                if (numInserted !== 1) {
+                    // idempotency key was inserted before, so this must be a retry
+                    await tx.rollback();
+                    return;
+                }
+        
+                // now make the actual update
+                await db.query(
+                    `UPDATE users
+                        SET credits = credits + ${update.addCredits}
+                      WHERE userid = '${update.userId}'`,
+                    { transaction: tx }
+                );
+        
+                // if everything succeeds, commit idempotency token and update atomically
+                await tx.commit();
+            }
+            catch (e) {
+                // speed up release of DB locks by eagerly aborting transaction
+                await tx.rollback();
+                throw e;
+            }
+        },
+
+        /**
+         * Deletes the idempotency key from the database.
+         * This handler is involked as a scheduled call from the handler that performs
+         * the update.
+         */
+        expireIdempotencyKey: async (_ctx: restate.Context, key: string) => {
+            await db.query(
+                `DELETE FROM user_idempotency
+                       WHERE id = '${key}'`
+            );
+        }
+    }
+})
+
+// ----------------------------------------------------------------------------
+
+restate.endpoint()
+    .bind(simpledbAccess)
+    .bind(keyedDbAccess)
+    .bind(idempotencyKeyDbAccess)
+    .listen(9080);

--- a/typescript/patterns-use-cases/database-access/tsconfig.json
+++ b/typescript/patterns-use-cases/database-access/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "module": "nodenext",
+    "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
A collection of access patterns for databases, from Restate handlers.

This both illustrates that in principle, one doesn't need to do anything different than for non-Restate code.
But at the same time, Restate gives you powerful building blocks to increase resilience and correctness.