### PR TITLE
Add simulated failure handler and/or improve error message 

### DIFF
--- a/rust/templates/rust/src/main.rs
+++ b/rust/templates/rust/src/main.rs
@@ -9,20 +9,41 @@ trait Greeter {
     async fn greet(name: String) -> Result<String, HandlerError>;
 }
 
+#[restate_sdk::service]
+trait GreeterFailure {
+    async fn greet(name: String) -> Result<String, HandlerError>;
+}
+
+
 struct GreeterImpl;
+struct GreeterFailureImpl;
 
 impl Greeter for GreeterImpl {
     async fn greet(&self, mut ctx: Context<'_>, name: String) -> Result<String, HandlerError> {
         // Durably execute a set of steps; resilient against failures
         let greeting_id = ctx.rand_uuid().to_string();
-        ctx.run(|| send_notification(&greeting_id, &name)).await?;
+        ctx.run(|| send_notification(&greeting_id, &name, false)).await?;
         ctx.sleep(Duration::from_millis(1000)).await?;
-        ctx.run(|| send_reminder(&greeting_id)).await?;
+        ctx.run(|| send_reminder(&greeting_id, false)).await?;
 
         // Respond to caller
         Ok(format!("Greetings {name}"))
     }
 }
+
+impl GreeterFailure for GreeterFailureImpl {
+    async fn greet(&self, mut ctnx: Context<'_>, name: String) -> Result<String, HandlerError> {
+        // Durably execute a set of steps; resilient against failures
+        let greeting_id = ctx.rand_uuid().to_string();
+        ctx.run(|| send_notification(&greeting_id, &name, true)).await?;
+        ctx.sleep(Duration::from_millis(1000)).await?;
+        ctx.run(|| send_reminder(&greeting_id, true)).await?;
+
+        // Respond to caller
+        Ok(format!("Greetings {name}"))
+    }
+}
+
 
 #[tokio::main]
 async fn main() {
@@ -32,6 +53,7 @@ async fn main() {
     HttpServer::new(
         Endpoint::builder()
             .bind(GreeterImpl.serve())
+            .bind(GreeterFailureImpl.serve())
             .build(),
     )
         .listen_and_serve("0.0.0.0:9080".parse().unwrap())

--- a/rust/templates/rust/src/utils.rs
+++ b/rust/templates/rust/src/utils.rs
@@ -2,19 +2,19 @@ use rand::random;
 use anyhow::{anyhow, Result};
 use restate_sdk::errors::HandlerError;
 
-pub async fn send_notification(greeting_id: &str, name: &str) -> Result<(), HandlerError> {
-    if random::<f32>() < 0.5 {
-        println!("👻 Failed to send notification: {} - {}", greeting_id, name);
-        return Err(HandlerError::from(anyhow!("Failed to send notification: {} - {}", greeting_id, name)));
+pub async fn send_notification(greeting_id: &str, name: &str, simulate_faulure:bool) -> Result<(), HandlerError> {
+    if simulate_faulure && random::<f32>() < 0.5 {
+        println!("[👻 SIMULATED] Failed to send notification: {} - {}", greeting_id, name);
+        return Err(HandlerError::from(anyhow!("[SIMULATED] Failed to send notification: {} - {}", greeting_id, name)));
     }
     println!("Notification sent: {} - {}", greeting_id, name);
     Ok(())
 }
 
-pub async fn send_reminder(greeting_id: &str)-> Result<(), HandlerError> {
-    if random::<f32>() < 0.5 {
-        println!("👻 Failed to send reminder:  - {}", greeting_id);
-        return Err(HandlerError::from(anyhow!("Failed to send reminder: {}", greeting_id)));
+pub async fn send_reminder(greeting_id: &str, simulate_faulure:bool)-> Result<(), HandlerError> {
+    if simulate_faulure && random::<f32>() < 0.5 {
+        println!("[👻 SIMULATED] Failed to send reminder:  - {}", greeting_id);
+        return Err(HandlerError::from(anyhow!("[SIMULATED] Failed to send reminder: {}", greeting_id)));
     }
     println!("Reminder sent: {}", greeting_id);
     Ok(())


### PR DESCRIPTION
Hi, just sharing this as potential improvement for the hello-world example. I was deploying on a multi-machine setup and missed that the example had a random failure by design and thought it was a problem with the networking set up.  Might be good to either include [SIMULATED] in the error logs, or offer up a handler that explicitly calls out the failure mode. 