### PR TITLE
add SharedObjectContext example to cart_object.rs

### DIFF
--- a/rust/tutorials/tour-of-restate-rust/src/part4/cart_object.rs
+++ b/rust/tutorials/tour-of-restate-rust/src/part4/cart_object.rs
@@ -11,6 +11,9 @@ pub(crate) trait CartObject {
     async fn checkout() -> Result<bool, HandlerError>;
     #[name = "expireTicket"]
     async fn expire_ticket(ticket_id: String) -> Result<(), HandlerError>;
+
+    #[shared]
+    async fn list() -> Result<String, HandlerError>;
 }
 
 pub struct CartObjectImpl;
@@ -99,5 +102,19 @@ impl CartObject for CartObjectImpl {
         }
 
         Ok(())
+    }
+
+    async fn list(
+        &self,
+        ctx: SharedObjectContext<'_>
+    ) -> Result<String, HandlerError> {
+        let mut tickets = ctx
+            .get::<Json<HashSet<String>>>("tickets")
+            .await?
+            .unwrap_or_default()
+            .into_inner();
+
+        let tickets_vec: Vec<String> = tickets.into_iter().collect();
+        Ok(tickets_vec.join(","))
     }
 }


### PR DESCRIPTION
SharedObjectContext is missing from the tutorial/example code, so added this CartObject/list handler. While this is covered in the SDK docs, nothing on the main Restate Docs site covers the shared/read-only functionality. Including it in the tour seems useful.