### PR TITLE
Fix broken link to ratelimiter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+<!-- markdown-link-check-disable -->
 [![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://docs.restate.dev)
 [![Discord](https://img.shields.io/discord/1128210118216007792?logo=discord)](https://discord.gg/skW3AZ6uGd)
-[![Slack](https://img.shields.io/discord/1128210118216007792?logo=discord)](https://join.slack.com/t/restatecommunity/shared_invite/zt-2v9gl005c-WBpr167o5XJZI1l7HWKImA)
-[![Twitter](https://img.shields.io/twitter/follow/restatedev.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=restatedev)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=fff)](https://join.slack.com/t/restatecommunity/shared_invite/zt-2v9gl005c-WBpr167o5XJZI1l7HWKImA)
+[![Twitter](https://img.shields.io/twitter/follow/restatedev.svg?style=social&label=Follow)](https://x.com/intent/follow?screen_name=restatedev)
+<!-- markdown-link-check-enable -->
 
 # Restate examples
 
@@ -10,7 +12,7 @@ challenges.
 
 * **Basics:** Small examples highlighting the basic building blocks, like
   durable execution or virtual objects.
- 
+
 * **Use Cases and Patterns:** Small specific use cases, like webhooks,
   workflows, asynchronous task queuing.
 
@@ -27,7 +29,7 @@ challenges.
 * **Tutorials:** A step-by-step guide that builds an application and introduces
   the Restate concepts on the way.
 
-## Example catalogs 
+## Example catalogs
 
 Have a look at the example catalog for your preferred SDK language:
 

--- a/go/README.md
+++ b/go/README.md
@@ -30,7 +30,7 @@
 - **[Event Enrichment / Joins](patterns-use-cases/README.md#event-enrichment--joins)**: Stateful functions/actors connected to Kafka and callable over RPC. [<img src="https://raw.githubusercontent.com/restatedev/img/refs/heads/main/play-button.svg" width="16" height="16">](patterns-use-cases/src/eventenrichment/packagetracker.go)
 
 #### Building coordination constructs (Advanced)
-- **[Rate Limiting](patterns-use-cases/README.md#rate-limiting)**: Example of implementing a token bucket rate limiter. [<img src="https://raw.githubusercontent.com/restatedev/img/refs/heads/main/play-button.svg" width="16" height="16">](patterns-use-cases/ratelimit)
+- **[Rate Limiting](patterns-use-cases/README.md#rate-limiting)**: Example of implementing a token bucket rate limiter. [<img src="https://raw.githubusercontent.com/restatedev/img/refs/heads/main/play-button.svg" width="16" height="16">](patterns-use-cases/src/ratelimit/service/limiter.go)
 
 ## Integrations
 


### PR DESCRIPTION
Not entirely sure whether changing from twitter.com to x.com will fix the broken twitter link. Maybe this is something that we need to exclude otherwise from the check.