### PR TITLE
Mark CronJob#getInfo handler as shared.

### DIFF
--- a/typescript/patterns-use-cases/src/cron/cron_service.ts
+++ b/typescript/patterns-use-cases/src/cron/cron_service.ts
@@ -94,7 +94,9 @@ export const cronJob = restate.object({
       // Clear the job state
       ctx.clearAll();
     },
-    getInfo: async (ctx: restate.ObjectSharedContext) => ctx.get<JobInfo>(JOB_STATE),
+    getInfo: restate.handlers.object.shared(async (ctx: restate.ObjectSharedContext) => {
+      return ctx.get<JobInfo>(JOB_STATE);
+    }),
   },
 });
 


### PR DESCRIPTION
This correctly marks the handler as shared.