### PR TITLE
Update email activation log message format in knative-go example

### DIFF
--- a/go/integrations/knative-go/main.go
+++ b/go/integrations/knative-go/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func sendEmail(log *slog.Logger, username string, id string) error {
-	log.Info("Sending email to activate account %s. To simulate the click on the email button, send a request to: POST http://localhost:8080/restate/awakeables/%s/resolve", username, id)
+	log.Info(fmt.Sprintf("Sending email to activate account %s. To simulate the click on the email button: curl -v -X POST http://localhost:8080/restate/awakeables/%s/resolve", username, id))
 	return nil
 }
 


### PR DESCRIPTION
Call `fmt.Sprintf` to format the `%s` string arguments, because `slog` does not.