### PR TITLE
Rename RESTATE_API_KEY env var to RESTATE_AUTH_TOKEN

### DIFF
--- a/.tools/run_node_tests.sh
+++ b/.tools/run_node_tests.sh
@@ -30,6 +30,6 @@ npm_install_check $PROJECT_ROOT/typescript/end-to-end-applications/food-ordering
 npm_install_check $PROJECT_ROOT/typescript/end-to-end-applications/chat-bot
 
 npm_install_check $PROJECT_ROOT/typescript/integrations/opentelemetry
-RESTATE_ENV_ID=env_test RESTATE_API_KEY=key_test npm_install_check $PROJECT_ROOT/typescript/integrations/deployment-lambda-cdk
+RESTATE_ENV_ID=env_test RESTATE_AUTH_TOKEN=key_test npm_install_check $PROJECT_ROOT/typescript/integrations/deployment-lambda-cdk
 
-RESTATE_ENV_ID=env_test RESTATE_API_KEY=key_test npm_install_check $PROJECT_ROOT/python/integrations/deployment-lambda-cdk
+RESTATE_ENV_ID=env_test RESTATE_AUTH_TOKEN=key_test npm_install_check $PROJECT_ROOT/python/integrations/deployment-lambda-cdk

--- a/go/integrations/go-lambda-cdk/README.md
+++ b/go/integrations/go-lambda-cdk/README.md
@@ -46,7 +46,7 @@ npm install
 To deploy the stack, export the Restate Cloud environment id and admin API key, and run `cdk deploy`:
 
 ```shell
-export RESTATE_ENV_ID=env_... RESTATE_API_KEY=key_...
+export RESTATE_ENV_ID=env_... RESTATE_AUTH_TOKEN=key_...
 npx cdk deploy
 ```
 
@@ -58,7 +58,7 @@ You can send a test request to the Restate ingress endpoint to call the newly de
 
 ```shell
 curl -k ${restateIngressUrl}/Greeter/Greet \
-  -H "Authorization: Bearer $RESTATE_API_KEY" \
+  -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" \
   -H 'content-type: application/json' -d '"Restate"'
 ```
 

--- a/go/integrations/go-lambda-cdk/cdk/go-lambda-cdk-stack.ts
+++ b/go/integrations/go-lambda-cdk/cdk/go-lambda-cdk-stack.ts
@@ -36,9 +36,9 @@ export class GoLambdaCdkStack extends cdk.Stack {
 
     // If you would prefer to manually register the Lambda service with your Restate environment,
     // you can remove or comment the rest of the code below this line.
-    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_API_KEY) {
+    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_AUTH_TOKEN) {
       throw new Error(
-        "Required environment variables RESTATE_ENV_ID and RESTATE_API_KEY are not set, please see README."
+        "Required environment variables RESTATE_ENV_ID and RESTATE_AUTH_TOKEN are not set, please see README."
       );
     }
 
@@ -54,7 +54,7 @@ export class GoLambdaCdkStack extends cdk.Stack {
         // See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/cdk.html
         apiKey: new secrets.Secret(this, "RestateCloudApiKey", {
           secretStringValue: cdk.SecretValue.unsafePlainText(
-            process.env.RESTATE_API_KEY!,
+            process.env.RESTATE_AUTH_TOKEN!,
           ),
         }),
       },

--- a/java/integrations/java-gradle-lambda-cdk/README.md
+++ b/java/integrations/java-gradle-lambda-cdk/README.md
@@ -47,7 +47,7 @@ npm install
 To deploy the stack, export the Restate Cloud environment id and API key, and run `cdk deploy`:
 
 ```shell
-export RESTATE_ENV_ID=env_... RESTATE_API_KEY=key_...
+export RESTATE_ENV_ID=env_... RESTATE_AUTH_TOKEN=key_...
 npx cdk deploy
 ```
 
@@ -59,7 +59,7 @@ You can send a test request to the Restate ingress endpoint to call the newly de
 
 ```shell
 curl -k ${restateIngressUrl}/Greeter/greet \
-  -H "Authorization: Bearer $RESTATE_API_KEY" \
+  -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" \
   -H 'content-type: application/json' -d '"Restate"'
 ```
 

--- a/java/integrations/java-gradle-lambda-cdk/cdk/lambda-jvm-cdk-stack.ts
+++ b/java/integrations/java-gradle-lambda-cdk/cdk/lambda-jvm-cdk-stack.ts
@@ -32,9 +32,9 @@ export class LambdaJvmCdkStack extends cdk.Stack {
 
     // If you would prefer to manually register the Lambda service with your Restate environment,
     // you can remove or comment the rest of the code below this line.
-    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_API_KEY) {
+    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_AUTH_TOKEN) {
       throw new Error(
-        "Required environment variables RESTATE_ENV_ID and RESTATE_API_KEY are not set, please see README."
+        "Required environment variables RESTATE_ENV_ID and RESTATE_AUTH_TOKEN are not set, please see README."
       );
     }
 
@@ -46,7 +46,7 @@ export class LambdaJvmCdkStack extends cdk.Stack {
       // For improved security, pre-populate the secret and pass it to the construct as a reference.
       // See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/cdk.html
       apiKey: new secrets.Secret(this, "RestateCloudApiKey", {
-        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_API_KEY!),
+        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_AUTH_TOKEN!),
       }),
     });
     const deployer = new restate.ServiceDeployer(this, "ServiceDeployer");

--- a/kotlin/integrations/kotlin-gradle-lambda-cdk/README.md
+++ b/kotlin/integrations/kotlin-gradle-lambda-cdk/README.md
@@ -48,7 +48,7 @@ npm install
 To deploy the stack, export the Restate Cloud environment id and API key, and run `cdk deploy`:
 
 ```shell
-export RESTATE_ENV_ID=env_... RESTATE_API_KEY=key_...
+export RESTATE_ENV_ID=env_... RESTATE_AUTH_TOKEN=key_...
 npx cdk deploy
 ```
 
@@ -60,7 +60,7 @@ You can send a test request to the Restate ingress endpoint to call the newly de
 
 ```shell
 curl -k ${restateIngressUrl}/Greeter/greet \
-  -H "Authorization: Bearer $RESTATE_API_KEY" \
+  -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" \
   -H 'content-type: application/json' -d '"Restate"'
 ```
 

--- a/kotlin/integrations/kotlin-gradle-lambda-cdk/cdk/lambda-jvm-cdk-stack.ts
+++ b/kotlin/integrations/kotlin-gradle-lambda-cdk/cdk/lambda-jvm-cdk-stack.ts
@@ -32,9 +32,9 @@ export class LambdaJvmCdkStack extends cdk.Stack {
 
     // If you would prefer to manually register the Lambda service with your Restate environment,
     // you can remove or comment the rest of the code below this line.
-    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_API_KEY) {
+    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_AUTH_TOKEN) {
       throw new Error(
-        "Required environment variables RESTATE_ENV_ID and RESTATE_API_KEY are not set, please see README."
+        "Required environment variables RESTATE_ENV_ID and RESTATE_AUTH_TOKEN are not set, please see README."
       );
     }
 
@@ -46,7 +46,7 @@ export class LambdaJvmCdkStack extends cdk.Stack {
       // For improved security, pre-populate the secret and pass it to the construct as a reference.
       // See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/cdk.html
       apiKey: new secrets.Secret(this, "RestateCloudApiKey", {
-        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_API_KEY!),
+        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_AUTH_TOKEN!),
       }),
     });
     const deployer = new restate.ServiceDeployer(this, "ServiceDeployer");

--- a/python/integrations/deployment-lambda-cdk/README.md
+++ b/python/integrations/deployment-lambda-cdk/README.md
@@ -45,7 +45,7 @@ npm install
 To deploy the stack, export the Restate Cloud environment id and API key, and run `cdk deploy`:
 
 ```shell
-export RESTATE_ENV_ID=env_... RESTATE_API_KEY=key_...
+export RESTATE_ENV_ID=env_... RESTATE_AUTH_TOKEN=key_...
 npx cdk deploy
 ```
 
@@ -57,7 +57,7 @@ You can send a test request to the Restate cluster ingress endpoint to call the 
 
 ```shell
 curl -k ${restateIngressUrl}/Greeter/greet \
-  -H "Authorization: Bearer $RESTATE_API_KEY" \
+  -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" \
   -H 'content-type: application/json' -d '"Restate"'
 ```
 

--- a/python/integrations/deployment-lambda-cdk/lib/lambda-python-stack.ts
+++ b/python/integrations/deployment-lambda-cdk/lib/lambda-python-stack.ts
@@ -40,9 +40,9 @@ export class LambdaPythonStack extends cdk.Stack {
 
     // If you would prefer to manually register the Lambda service with your Restate environment,
     // you can remove or comment the rest of the code below this line.
-    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_API_KEY) {
+    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_AUTH_TOKEN) {
       throw new Error(
-        "Required environment variables RESTATE_ENV_ID and RESTATE_API_KEY are not set, please see README."
+        "Required environment variables RESTATE_ENV_ID and RESTATE_AUTH_TOKEN are not set, please see README."
       );
     }
 
@@ -54,7 +54,7 @@ export class LambdaPythonStack extends cdk.Stack {
       // For improved security, pre-populate the secret and pass it to the construct as a reference.
       // See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/cdk.html
       apiKey: new secrets.Secret(this, "RestateCloudApiKey", {
-        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_API_KEY!),
+        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_AUTH_TOKEN!),
       }),
     });
     const deployer = new restate.ServiceDeployer(this, "ServiceDeployer");

--- a/typescript/integrations/deployment-lambda-cdk/README.md
+++ b/typescript/integrations/deployment-lambda-cdk/README.md
@@ -46,7 +46,7 @@ npm install
 To deploy the stack, export the Restate Cloud environment id and API key, and run `cdk deploy`:
 
 ```shell
-export RESTATE_ENV_ID=env_... RESTATE_API_KEY=key_...
+export RESTATE_ENV_ID=env_... RESTATE_AUTH_TOKEN=key_...
 npx cdk deploy
 ```
 
@@ -58,7 +58,7 @@ You can send a test request to the Restate cluster ingress endpoint to call the 
 
 ```shell
 curl -k ${restateIngressUrl}/Greeter/greet \
-  -H "Authorization: Bearer $RESTATE_API_KEY" \
+  -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" \
   -H 'content-type: application/json' -d '"Restate"'
 ```
 

--- a/typescript/integrations/deployment-lambda-cdk/lib/lambda-ts-cdk-stack.ts
+++ b/typescript/integrations/deployment-lambda-cdk/lib/lambda-ts-cdk-stack.ts
@@ -32,9 +32,9 @@ export class LambdaTsCdkStack extends cdk.Stack {
 
     // If you would prefer to manually register the Lambda service with your Restate environment,
     // you can remove or comment the rest of the code below this line.
-    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_API_KEY) {
+    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_AUTH_TOKEN) {
       throw new Error(
-        "Required environment variables RESTATE_ENV_ID and RESTATE_API_KEY are not set, please see README.",
+        "Required environment variables RESTATE_ENV_ID and RESTATE_AUTH_TOKEN are not set, please see README.",
       );
     }
 
@@ -46,7 +46,7 @@ export class LambdaTsCdkStack extends cdk.Stack {
       // For improved security, pre-populate the secret and pass it to the construct as a reference.
       // See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/cdk.html
       apiKey: new secrets.Secret(this, "RestateCloudApiKey", {
-        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_API_KEY!),
+        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_AUTH_TOKEN!),
       }),
     });
     const deployer = new restate.ServiceDeployer(this, "ServiceDeployer");

--- a/typescript/templates/nextjs/app/actions.ts
+++ b/typescript/templates/nextjs/app/actions.ts
@@ -60,9 +60,9 @@ function getRestateUrl(): string {
 
 function getRestateAuthHeaders(): Record<string, string> {
   if (process.env.VERCEL) {
-    const apiKey = process.env.RESTATE_API_KEY;
+    const apiKey = process.env.RESTATE_AUTH_TOKEN;
     if (!apiKey) {
-      throw new Error('RESTATE_API_KEY environment variable is not set');
+      throw new Error('RESTATE_AUTH_TOKEN environment variable is not set');
     }
     return {
       Authorization: "Bearer " + apiKey,


### PR DESCRIPTION
Use RESTATE_AUTH_TOKEN everywhere for consistency, based on customer feedback.

## Summary

- Renames the `RESTATE_API_KEY` environment variable to `RESTATE_AUTH_TOKEN` across the five CDK Lambda examples (TypeScript, Go, Java, Kotlin, Python), the Next.js template, and the integration test runner.
- The Restate CLI and the docs/UI consistently use `RESTATE_AUTH_TOKEN` for the API key already; only these examples were the outlier. A customer flagged the inconsistency between docs pages and tooling, which surfaced when configuring deployments end-to-end.

## Files touched

- `typescript/integrations/deployment-lambda-cdk/{lib/lambda-ts-cdk-stack.ts,README.md}`
- `go/integrations/go-lambda-cdk/{cdk/go-lambda-cdk-stack.ts,README.md}`
- `java/integrations/java-gradle-lambda-cdk/{cdk/lambda-jvm-cdk-stack.ts,README.md}`
- `kotlin/integrations/kotlin-gradle-lambda-cdk/{cdk/lambda-jvm-cdk-stack.ts,README.md}`
- `python/integrations/deployment-lambda-cdk/{lib/lambda-python-stack.ts,README.md}`
- `typescript/templates/nextjs/app/actions.ts`
- `.tools/run_node_tests.sh`

This is a straight rename with no backward compatibility shim: callers must update their environment to use the new variable name.

## Test plan

- [ ] CI builds for all five CDK examples pass with `RESTATE_AUTH_TOKEN=key_test` (the test runner was updated to set the new name)
- [ ] Manual `cdk synth` of the TypeScript stack with `RESTATE_AUTH_TOKEN` set produces a valid template
- [ ] Stack now fails with the expected error message when neither `RESTATE_ENV_ID` nor `RESTATE_AUTH_TOKEN` are set
- [ ] Companion docs PR in `restatedev/docs-restate` is merged so the CDK code block on `docs/cloud/connecting-services` stays in sync