### PR TITLE
Ignore slack.restate.dev in markdown link check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: echo '{"ignorePatterns":[{"pattern":"https://docs.restate.dev/_mintlify/feedback/restate-6d46e1dc/agent-feedback"}]}' > mlc_config.json
+      - run: echo '{"ignorePatterns":[{"pattern":"https://docs.restate.dev/_mintlify/feedback/restate-6d46e1dc/agent-feedback"},{"pattern":"https://slack.restate.dev"}]}' > mlc_config.json
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: 'yes'


### PR DESCRIPTION
## Summary

The `markdown-link-check` job currently fails on every PR because Cloudflare returns 403 to the GitHub Actions runner when it requests `https://slack.restate.dev`. The URL itself is fine for humans (302 redirect to the Slack workspace invite), but the link checker's user agent gets blocked. This was introduced in commit af9b6776 ("Fix codex authentication") which switched several READMEs to the new vanity URL.

This adds `https://slack.restate.dev` to the `mlc_config.json` ignore list so unrelated PRs stop failing on this flake. The `discord.restate.dev` vanity URL passes fine and isn't affected.

## Test plan

- [x] CI on this PR passes (the link-check job specifically)
- [ ] After merge, re-run CI on PR #389 (and any other open PR) and confirm the markdown-link-check job is green